### PR TITLE
Don't merge repeated characters in ctc_beam_search_decoder, fixes #53

### DIFF
--- a/DeepSpeech.ipynb
+++ b/DeepSpeech.ipynb
@@ -661,7 +661,7 @@
     "    avg_loss = tf.reduce_mean(total_loss)\n",
     "    \n",
     "    # Beam search decode the batch\n",
-    "    decoded, _ = ctc_ops.ctc_beam_search_decoder(logits, batch_seq_len)\n",
+    "    decoded, _ = ctc_ops.ctc_beam_search_decoder(logits, batch_seq_len, merge_repeated=False)\n",
     "    \n",
     "    # Compute the edit (Levenshtein) distance \n",
     "    distance = tf.edit_distance(tf.cast(decoded[0], tf.int32), batch_y)\n",


### PR DESCRIPTION
The documentation is unclear, so I tested this on the ldc set by changing the 'year' in sentence to 'lear', so it included the sequence 'all lear' (which has a repeated character, then a space, then the same character - which I wanted to verify also). I was able to over-fit and produce the correct result.