### PR TITLE
Separate libdeepspeech/c_speech_features/kissfft library builds

### DIFF
--- a/native_client/BUILD
+++ b/native_client/BUILD
@@ -2,18 +2,28 @@
 
 cc_library(
     name = "deepspeech",
-    srcs = ["deepspeech.cc",
-            "c_speech_features/c_speech_features.c",
-            "kiss_fft130/kiss_fft.c",
+    srcs = ["deepspeech.cc"],
+    hdrs = ["deepspeech.h"],
+    deps = ["//tensorflow/core:tensorflow",
+            ":c_speech_features"]
+)
+
+cc_library(
+    name = "kissfft",
+    srcs = ["kiss_fft130/kiss_fft.c",
             "kiss_fft130/tools/kiss_fftr.c"],
-    hdrs = ["deepspeech.h",
-            "c_speech_features/c_speech_features.h",
-            "kiss_fft130/kiss_fft.h",
+    hdrs = ["kiss_fft130/kiss_fft.h",
             "kiss_fft130/_kiss_fft_guts.h",
             "kiss_fft130/tools/kiss_fftr.h"],
-    includes = ["c_speech_features",
-                "kiss_fft130"],
-    deps = [
-        "//tensorflow/core:tensorflow"
-    ]
+    includes = ["kiss_fft130"]
+)
+
+# Note, we need gnu99 as opposed to c99 as the latter doesn't define M_PI
+cc_library(
+    name="c_speech_features",
+    srcs = ["c_speech_features/c_speech_features.c"],
+    hdrs = ["c_speech_features/c_speech_features.h"],
+    includes = ["c_speech_features"],
+    deps = [":kissfft"],
+    copts = ["-std=gnu99"]
 )

--- a/native_client/Makefile
+++ b/native_client/Makefile
@@ -8,7 +8,7 @@ clean:
 	rm -f deepspeech
 
 deepspeech: client.cc
-	c++ -o deepspeech ${CFLAGS} client.cc `pkg-config --cflags --libs sox` -L${TFDIR}/bazel-bin/tensorflow -L${TFDIR}/bazel-bin/native_client -ldeepspeech -ltensorflow
+	c++ -o deepspeech ${CFLAGS} client.cc `pkg-config --cflags --libs sox` -L${TFDIR}/bazel-bin/tensorflow -L${TFDIR}/bazel-bin/native_client -lkissfft -lc_speech_features -ltensorflow -ldeepspeech
 
 run: deepspeech
 	LD_LIBRARY_PATH=${TFDIR}/bazel-bin/tensorflow:${TFDIR}/bazel-bin/native_client:${LD_LIBRARY_PATH} ./deepspeech ${ARGS}

--- a/native_client/README.md
+++ b/native_client/README.md
@@ -29,7 +29,7 @@ bazel build -c opt //tensorflow:libtensorflow.so
 Then you can build the DeepSpeech native library.
 
 ```
-bazel build -c opt //native_client:deepspeech
+bazel build -c opt //native_client:*
 ```
 
 Finally, you can change to the `native_client` directory and use the `Makefile`. By default, the `Makefile` will assume there is a TensorFlow checkout in a directory above the DeepSpeech checkout. If that is not the case, set the environment variable `TFDIR` to point to the right directory.


### PR DESCRIPTION
Build separate libraries for kissfft, c_speech_features and libdeepspeech.
This allows us to specify c99 for c_speech_features and should fix
issue #441.