### PR TITLE
Allow for running under Python 3.6

### DIFF
--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 # -*- coding: utf-8 -*-
 
 import datetime
@@ -632,13 +633,13 @@ def calculate_and_print_wer_report(caption, results_tuple):
     # Order this top ten items by their WER (lowest WER on top)
     items.sort(key=lambda a: a[2])
 
-    print "%s WER: %f" % (caption, mean_wer)
+    print("%s WER: %f" % (caption, mean_wer))
     for a in items:
-        print "-" * 80
-        print "    WER:    %f" % a[2]
-        print "    loss:   %f" % a[3]
-        print "    source: \"%s\"" % a[0]
-        print "    result: \"%s\"" % a[1]
+        print("-" * 80)
+        print("    WER:    %f" % a[2])
+        print("    loss:   %f" % a[3])
+        print("    source: \"%s\"" % a[0])
+        print("    result: \"%s\"" % a[1])
 
     return mean_wer
 
@@ -993,7 +994,7 @@ def print_report(caption, batch_set_result):
         title += " avg_cer=" + "{:.9f}".format(accuracy)
         mean_wer = calculate_and_print_wer_report(title, results_tuple)
     else:
-        print title
+        print(title)
 
     return mean_wer
 
@@ -1030,7 +1031,7 @@ def train():
     Now, as we have prepared all the apropos operators and methods,
     we can create the method which trains the network.
     """
-    print "STARTING Optimization\n"
+    print("STARTING Optimization\n")
     global_time = stopwatch()
     global_train_time = 0
 
@@ -1051,15 +1052,15 @@ def train():
         if checkpoint and checkpoint.model_checkpoint_path:
             hibernation_path = checkpoint.model_checkpoint_path
             start_epoch = int(checkpoint.model_checkpoint_path.split('-')[-1])
-            print 'Resuming training from epoch %d' % (start_epoch + 1)
+            print('Resuming training from epoch %d' % (start_epoch + 1))
 
     # Loop over the data set for training_epochs epochs
     for epoch in range(start_epoch, epochs):
-        print "STARTING Epoch", '%04d' % (epoch)
+        print("STARTING Epoch", '%04d' % (epoch))
 
         if epoch == 0 or hibernation_path is not None:
             if hibernation_path is not None:
-                print "Resuming training session from", "%s" % hibernation_path, "..."
+                print("Resuming training session from", "%s" % hibernation_path, "...")
             session, coord, managed_threads = start_execution_context(train_context, hibernation_path)
             # Flag that execution context has started
             execution_context_running = True
@@ -1074,7 +1075,7 @@ def train():
         is_validation_step = validation_step > 0 and (epoch + 1) % validation_step == 0
         is_checkpoint_step = (checkpoint_step > 0 and (epoch + 1) % checkpoint_step == 0) or epoch == epochs - 1
 
-        print "Training model..."
+        print("Training model...")
         global_train_time = stopwatch(global_train_time)
         train_time = stopwatch(train_time)
         result = calculate_loss_and_report(train_context, session, epoch=epoch, query_report=is_display_step)
@@ -1088,13 +1089,13 @@ def train():
 
         # Checkpoint step (Validation also checkpoints)
         if is_checkpoint_step and not is_validation_step:
-            print "Hibernating training session into directory", "%s" % checkpoint_dir
+            print("Hibernating training session into directory", "%s" % checkpoint_dir)
             checkpoint_path = os.path.join(checkpoint_dir, 'model.ckpt')
             # Saving session's model into checkpoint path
             persist_model(train_context, session, checkpoint_path, epoch)
         # Validation step
         if is_validation_step:
-            print "Hibernating training session into directory", "%s" % checkpoint_dir
+            print("Hibernating training session into directory", "%s" % checkpoint_dir)
             checkpoint_path = os.path.join(checkpoint_dir, 'model.ckpt')
             # If the hibernation_path is set, the next epoch loop will load the model
             hibernation_path = stop_execution_context(train_context, session, coord, managed_threads, checkpoint_path=checkpoint_path, global_step=epoch)
@@ -1102,7 +1103,7 @@ def train():
             execution_context_running = False
 
             # Validating the model in a fresh session
-            print "Validating model..."
+            print("Validating model...")
             result = run_set('dev', model_path=hibernation_path, query_report=True)
             result = print_report("Validation", result)
             # If there was a WER calculated, we keep it
@@ -1111,20 +1112,20 @@ def train():
 
         overall_time = stopwatch(overall_time)
 
-        print "FINISHED Epoch", '%04d' % (epoch),\
+        print("FINISHED Epoch", '%04d' % (epoch),\
               "  Overall epoch time:", format_duration(overall_time),\
-              "  Training time:", format_duration(train_time)
-        print
+              "  Training time:", format_duration(train_time))
+        print()
 
     # If the last iteration step was no validation, we still have to save the model
     if hibernation_path is None or execution_context_running:
         hibernation_path = stop_execution_context(train_context, session, coord, managed_threads, checkpoint_path=checkpoint_path, global_step=epoch)
 
     # Indicate optimization has concluded
-    print "FINISHED Optimization",\
+    print("FINISHED Optimization",\
           "  Overall time:", format_duration(stopwatch(global_time)),\
-          "  Training time:", format_duration(global_train_time)
-    print
+          "  Training time:", format_duration(global_train_time))
+    print()
 
     return train_wer, dev_wer, hibernation_path
 
@@ -1146,7 +1147,7 @@ if __name__ == "__main__":
         duration = duration.days * 86400 + duration.seconds
 
         # Finally the model is tested against some unbiased data-set
-        print "Testing model"
+        print("Testing model")
         result = run_set('test', model_path=hibernation_path, query_report=True)
         test_wer = print_report("Test", result)
 
@@ -1190,7 +1191,7 @@ if __name__ == "__main__":
             checkpoint = tf.train.get_checkpoint_state(checkpoint_dir)
             checkpoint_path = checkpoint.model_checkpoint_path
             saver.restore(session, checkpoint_path)
-            print 'Restored checkpoint at training epoch %d' % (int(checkpoint_path.split('-')[-1]) + 1)
+            print('Restored checkpoint at training epoch %d' % (int(checkpoint_path.split('-')[-1]) + 1))
 
             # Initialise the model exporter and export the model
             model_exporter.init(session.graph.as_graph_def(),
@@ -1202,7 +1203,7 @@ if __name__ == "__main__":
             if remove_export:
                 actual_export_dir = os.path.join(export_dir, '%08d' % export_version)
                 if os.path.isdir(actual_export_dir):
-                    print 'Removing old export'
+                    print('Removing old export')
                     shutil.rmtree(actual_export_dir)
             try:
                 # Export serving model
@@ -1226,9 +1227,9 @@ if __name__ == "__main__":
                                           restore_op_name, filename_tensor_name,
                                           output_graph_path, clear_devices, '')
 
-                print 'Models exported at %s' % (export_dir)
+                print('Models exported at %s' % (export_dir))
             except RuntimeError:
-                print  sys.exc_info()[1]
+                print(sys.exc_info()[1])
 
 
     # Logging Hyper Parameters and Results

--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 from __future__ import print_function
+from __future__ import absolute_import
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
 import datetime
 import json
 import numpy as np

--- a/demos/deepspeech_demos.py
+++ b/demos/deepspeech_demos.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2.7
-
+#!/usr/bin/env python
+from __future__ import print_function
 """A client that talks to tensorflow_model_server loaded with deepspeech model.
 
 The client launches a local web server, by default accessible at localhost:8080

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ sox
 python_speech_features
 pyxdg
 bs4
+six
 https://github.com/kpu/kenlm/archive/master.zip

--- a/util/audio.py
+++ b/util/audio.py
@@ -1,7 +1,9 @@
+from __future__ import absolute_import
 import numpy as np
 import scipy.io.wavfile as wav
 
 from python_speech_features import mfcc
+from six.moves import range
 
 def audiofile_to_input_vector(audio_filename, numcep, numcontext):
     r"""
@@ -33,7 +35,7 @@ def audiofile_to_input_vector(audio_filename, numcep, numcontext):
     empty_mfcc.resize((numcep))
 
     # Prepare train_inputs with past and future contexts
-    time_slices = range(train_inputs.shape[0])
+    time_slices = list(range(train_inputs.shape[0]))
     context_past_min   = time_slices[0]  + numcontext
     context_future_max = time_slices[-1] - numcontext
     for time_slice in time_slices:

--- a/util/automation.py
+++ b/util/automation.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-
 from __future__ import print_function
 from __future__ import absolute_import
 import json
@@ -21,9 +20,9 @@ from threading import Thread
 from time import time
 from scipy.interpolate import spline
 
+from six.moves import range
 # Do this to be able to use without X
 import matplotlib as mpl
-from six.moves import range
 mpl.use('Agg')
 import matplotlib.pyplot as plt
 import numpy as np

--- a/util/automation.py
+++ b/util/automation.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 
 from __future__ import print_function
+from __future__ import absolute_import
 import json
 import os
 import git
@@ -22,6 +23,7 @@ from scipy.interpolate import spline
 
 # Do this to be able to use without X
 import matplotlib as mpl
+from six.moves import range
 mpl.use('Agg')
 import matplotlib.pyplot as plt
 import numpy as np
@@ -162,7 +164,7 @@ class GPUUsageChart():
             print("Data was empty, aborting")
             return
 
-        x = range(len(data[0]))
+        x = list(range(len(data[0])))
         if with_spline:
             x = map(lambda x: float(x), x)
             x_sm = np.array(x)

--- a/util/importers/LDC97S62.py
+++ b/util/importers/LDC97S62.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import fnmatch
 import numpy as np
 import os

--- a/util/importers/LDC97S62.py
+++ b/util/importers/LDC97S62.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import absolute_import
 import fnmatch
 import numpy as np
 import os
@@ -16,6 +17,7 @@ from threading import Thread
 from util.audio import audiofile_to_input_vector
 from util.gpu import get_available_gpus
 from util.text import text_to_char_array, ctc_label_dense_to_sparse, validate_label
+from six.moves import range
 
 class DataSets(object):
     def __init__(self, train, dev, test):
@@ -66,7 +68,7 @@ class DataSet(object):
 
     def start_queue_threads(self, session, coord):
         self._coord = coord
-        batch_threads = [Thread(target=self._populate_batch_queue, args=(session,)) for i in xrange(self._thread_count)]
+        batch_threads = [Thread(target=self._populate_batch_queue, args=(session,)) for i in range(self._thread_count)]
         for batch_thread in batch_threads:
             batch_thread.daemon = True
             batch_thread.start()

--- a/util/importers/fisher.py
+++ b/util/importers/fisher.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import fnmatch
 import os
 import subprocess

--- a/util/importers/fisher.py
+++ b/util/importers/fisher.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import absolute_import
 import fnmatch
 import os
 import subprocess
@@ -15,6 +16,7 @@ from threading import Thread
 from util.audio import audiofile_to_input_vector
 from util.gpu import get_available_gpus
 from util.text import text_to_char_array, validate_label, ctc_label_dense_to_sparse
+from six.moves import range
 
 class DataSets(object):
     def __init__(self, train, dev, test):
@@ -64,7 +66,7 @@ class DataSet(object):
     
     def start_queue_threads(self, session, coord):
         self._coord = coord
-        batch_threads = [Thread(target=self._populate_batch_queue, args=(session,)) for i in xrange(self._thread_count)]
+        batch_threads = [Thread(target=self._populate_batch_queue, args=(session,)) for i in range(self._thread_count)]
         for batch_thread in batch_threads:
             batch_thread.daemon = True
             batch_thread.start()

--- a/util/importers/ldc93s1.py
+++ b/util/importers/ldc93s1.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import tensorflow as tf
 
 from os import path
@@ -8,6 +9,7 @@ from util.gpu import get_available_gpus
 from util.text import text_to_char_array, ctc_label_dense_to_sparse
 from util.audio import audiofile_to_input_vector
 from tensorflow.contrib.learn.python.learn.datasets import base
+from six.moves import range
 
 class DataSets(object):
     def __init__(self, train, dev, test):
@@ -56,7 +58,7 @@ class DataSet(object):
 
     def start_queue_threads(self, session, coord):
         self._coord = coord
-        batch_threads = [Thread(target=self._populate_batch_queue, args=(session,)) for i in xrange(self._thread_count)]
+        batch_threads = [Thread(target=self._populate_batch_queue, args=(session,)) for i in range(self._thread_count)]
         for batch_thread in batch_threads:
             batch_thread.daemon = True
             batch_thread.start()

--- a/util/importers/librivox.py
+++ b/util/importers/librivox.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import codecs
 import fnmatch
 import os

--- a/util/importers/librivox.py
+++ b/util/importers/librivox.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from __future__ import absolute_import
 import codecs
 import fnmatch
 import os
@@ -21,6 +22,7 @@ from tensorflow.python.platform import gfile
 from util.audio import audiofile_to_input_vector
 from util.gpu import get_available_gpus
 from util.text import text_to_char_array, ctc_label_dense_to_sparse
+from six.moves import range
 
 
 class DataSets(object):
@@ -72,7 +74,7 @@ class DataSet(object):
 
     def start_queue_threads(self, session, coord):
         self._coord = coord
-        batch_threads = [Thread(target=self._populate_batch_queue, args=(session,)) for i in xrange(self._thread_count)]
+        batch_threads = [Thread(target=self._populate_batch_queue, args=(session,)) for i in range(self._thread_count)]
         for batch_thread in batch_threads:
             batch_thread.daemon = True
             batch_thread.start()

--- a/util/importers/librivox.py
+++ b/util/importers/librivox.py
@@ -133,7 +133,7 @@ def read_data_sets(data_dir, train_batch_size, dev_batch_size, test_batch_size, 
         print("Error: SoX doesn't support FLAC. Please install SoX with FLAC support and try again.")
         exit(1)
     # Conditionally download data to data_dir
-    print("Downloading Librivox data sets if not already present...")
+    print("Downloading Librivox data set (55GB) into %s if not already present..."%(data_dir,))
     with progressbar.ProgressBar(max_value=7, widget=progressbar.AdaptiveETA) as bar:
         TRAIN_CLEAN_100_URL = "http://www.openslr.org/resources/12/train-clean-100.tar.gz"
         TRAIN_CLEAN_360_URL = "http://www.openslr.org/resources/12/train-clean-360.tar.gz"
@@ -146,7 +146,6 @@ def read_data_sets(data_dir, train_batch_size, dev_batch_size, test_batch_size, 
         TEST_OTHER_URL = "http://www.openslr.org/resources/12/test-other.tar.gz"
 
         def filename_of(x): return path.split(x)[1]
-
         train_clean_100 = base.maybe_download(filename_of(TRAIN_CLEAN_100_URL), data_dir, TRAIN_CLEAN_100_URL)
         bar.update(0)
         train_clean_360 = base.maybe_download(filename_of(TRAIN_CLEAN_360_URL), data_dir, TRAIN_CLEAN_360_URL)

--- a/util/importers/librivox.py
+++ b/util/importers/librivox.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 import tarfile
 import unicodedata
-from Queue import PriorityQueue
+from six.moves.queue import PriorityQueue
 from glob import glob
 from itertools import cycle
 from math import ceil
@@ -128,7 +128,7 @@ class DataSet(object):
 def read_data_sets(data_dir, train_batch_size, dev_batch_size, test_batch_size, numcep, numcontext, thread_count=8,
                    limit_dev=0, limit_test=0, limit_train=0, sets=[]):
     # Check if we can convert FLAC with SoX before we start
-    sox_help_out = subprocess.check_output(["sox", "-h"])
+    sox_help_out = subprocess.check_output(["sox", "-h"]).decode('latin-1')
     if sox_help_out.find("flac") == -1:
         print("Error: SoX doesn't support FLAC. Please install SoX with FLAC support and try again.")
         exit(1)

--- a/util/importers/ted.py
+++ b/util/importers/ted.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import wave
 import random
 import tarfile
@@ -25,6 +26,7 @@ from util.text import text_to_char_array, ctc_label_dense_to_sparse
 from tensorflow.python.platform import gfile
 from util.audio import audiofile_to_input_vector
 from tensorflow.contrib.learn.python.learn.datasets import base
+from six.moves import range
 
 class DataSets(object):
     def __init__(self, train, dev, test):
@@ -74,7 +76,7 @@ class DataSet(object):
 
     def start_queue_threads(self, session, coord):
         self._coord = coord
-        batch_threads = [Thread(target=self._populate_batch_queue, args=(session,)) for i in xrange(self._thread_count)]
+        batch_threads = [Thread(target=self._populate_batch_queue, args=(session,)) for i in range(self._thread_count)]
         for batch_thread in batch_threads:
             batch_thread.daemon = True
             batch_thread.start()

--- a/util/importers/ted.py
+++ b/util/importers/ted.py
@@ -88,11 +88,11 @@ class DataSet(object):
     def _create_files_circular_list(self):
         priorityQueue = PriorityQueue()
         for txt_file in self._txt_files:
-          stm_dir = path.sep + "stm" + path.sep
-          wav_dir = path.sep + "wav" + path.sep
-          wav_file = path.splitext(txt_file.replace(stm_dir, wav_dir))[0] + ".wav"
-          wav_file_size = getsize(wav_file)
-          priorityQueue.put((wav_file_size, (txt_file, wav_file)))
+            stm_dir = path.sep + "stm" + path.sep
+            wav_dir = path.sep + "wav" + path.sep
+            wav_file = path.splitext(txt_file.replace(stm_dir, wav_dir))[0] + ".wav"
+            wav_file_size = getsize(wav_file)
+            priorityQueue.put((wav_file_size, (txt_file, wav_file)))
         files_list = []
         while not priorityQueue.empty():
             priority, (txt_file, wav_file) = priorityQueue.get()
@@ -169,9 +169,9 @@ def read_data_sets(data_dir, train_batch_size, dev_batch_size, test_batch_size, 
 def _maybe_extract(data_dir, extracted_data, archive):
     # If data_dir/extracted_data does not exist, extract archive in data_dir
     if not gfile.Exists(path.join(data_dir, extracted_data)):
-      tar = tarfile.open(archive)
-      tar.extractall(data_dir)
-      tar.close()
+        tar = tarfile.open(archive)
+        tar.extractall(data_dir)
+        tar.close()
 
 def _maybe_convert_wav(data_dir, extracted_data):
     # Create extracted_data dir
@@ -303,7 +303,7 @@ def _maybe_split_stm_dataset(extracted_dir, data_set):
             # If the txt segment file does not exist create it
             if not gfile.Exists(txt_file):
                 with open(txt_file, "w+") as f:
-                  f.write(stm_segment.transcript)
+                    f.write(stm_segment.transcript)
 
         # Remove stm_file
         remove(stm_file)

--- a/util/shared_lib.py
+++ b/util/shared_lib.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
-from .gpu import get_available_gpus
+from __future__ import absolute_import
+from util.gpu import get_available_gpus
 from ctypes import cdll
 from sys import platform as _platform
 

--- a/util/shared_lib.py
+++ b/util/shared_lib.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from gpu import get_available_gpus
 from ctypes import cdll
 from sys import platform as _platform
@@ -17,11 +18,11 @@ def check_cupti():
     libname = get_cupti_libname()
     cupti = check_so(libname)
     if cupti is None:
-        print "INFO: No %s because no GPU, go ahead." % libname
+        print("INFO: No %s because no GPU, go ahead." % libname)
     elif cupti is True:
-        print "INFO: Found %s." % libname
+        print("INFO: Found %s." % libname)
     else:
-        print "WARNING: Running on GPU but no %s could be found ; will be unable to report GPU VRAM usage." % libname
+        print("WARNING: Running on GPU but no %s could be found ; will be unable to report GPU VRAM usage." % libname)
 
 def check_so(soname):
     """
@@ -35,10 +36,10 @@ def check_so(soname):
     # Try to force load lib, this would fail if the lib is not there :)
     try:
         lib = cdll.LoadLibrary(soname)
-        print "INFO: Found so as", lib
+        print("INFO: Found so as", lib)
         assert lib.__class__.__name__ == 'CDLL'
         assert lib._name == soname
         return True
     except OSError as ex:
-        print "WARNING:", ex
+        print("WARNING:", ex)
         return False

--- a/util/shared_lib.py
+++ b/util/shared_lib.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from gpu import get_available_gpus
+from .gpu import get_available_gpus
 from ctypes import cdll
 from sys import platform as _platform
 

--- a/util/spell.py
+++ b/util/spell.py
@@ -1,6 +1,8 @@
+from __future__ import absolute_import
 import re
 import kenlm
 from heapq import heapify
+from six.moves import range
 
 # Define beam with for alt sentence search
 BEAM_WIDTH = 1024

--- a/util/text.py
+++ b/util/text.py
@@ -1,6 +1,9 @@
+from __future__ import absolute_import
 import numpy as np
 import tensorflow as tf
 import re
+from six.moves import range
+from functools import reduce
 
 # Constants
 SPACE_TOKEN = '<space>'
@@ -39,7 +42,7 @@ def sparse_tuple_from(sequences, dtype=np.int32):
     values = []
 
     for n, seq in enumerate(sequences):
-        indices.extend(zip([n]*len(seq), xrange(len(seq))))
+        indices.extend(zip([n]*len(seq), range(len(seq))))
         values.extend(seq)
 
     indices = np.asarray(indices, dtype=np.int64)
@@ -116,7 +119,7 @@ def levenshtein(a,b):
         a,b = b,a
         n,m = m,n
 
-    current = range(n+1)
+    current = list(range(n+1))
     for i in range(1,m+1):
         previous, current = current, [i]+[0]*n
         for j in range(1,n+1):
@@ -137,7 +140,7 @@ def gather_nd(params, indices, shape):
     rank = len(shape)
     flat_params = tf.reshape(params, [-1])
     multipliers = [reduce(lambda x, y: x*y, shape[i+1:], 1) for i in range(0, rank)]
-    indices_unpacked = tf.unstack(tf.transpose(indices, [rank - 1] + range(0, rank - 1)))
+    indices_unpacked = tf.unstack(tf.transpose(indices, [rank - 1] + list(range(0, rank - 1))))
     flat_indices = sum([a*b for a,b in zip(multipliers, indices_unpacked)])
     return tf.gather(flat_params, flat_indices)
 

--- a/util/website.py
+++ b/util/website.py
@@ -7,6 +7,7 @@ import sys
 from bs4 import BeautifulSoup
 from .log import merge_logs
 
+
 def parse_for_deps(filename):
     """
     This takes an HTML file as input and output a list of existing depenencies.
@@ -137,18 +138,20 @@ def maybe_publish(file='index.htm'):
     }
 
     for key in ssh_auth_infos.keys():
-       vartype = type(ssh_auth_infos[key])
-       value = os.environ.get(key)
-       if value is not None:
-           if vartype == str:
-               ssh_auth_infos[key] = str(os.environ.get(key))
-           elif vartype == int:
-               try:
-                   ssh_auth_infos[key] = int(os.environ.get(key))
-               except TypeError as ex:
-                   print("WARNING:", "Keeping default SSH port value because of:", ex)
-
-    missing_env = filter(lambda x: len(str(ssh_auth_infos[x])) == 0, ssh_auth_infos.keys())
+        vartype = type(ssh_auth_infos[key])
+        value = os.environ.get(key)
+        if value is not None:
+            if vartype == str:
+                ssh_auth_infos[key] = str(os.environ.get(key))
+            elif vartype == int:
+                try:
+                    ssh_auth_infos[key] = int(os.environ.get(key))
+                except TypeError as ex:
+                    print("WARNING:", "Keeping default SSH port value because of:", ex)
+    missing_env = [
+        x for x in ssh_auth_infos.keys()
+        if (len(str(ssh_auth_infos[x])) == 0)
+    ]
     if len(missing_env) > 0:
         print("Not publishing, missing some required environment variables:", missing_env)
         print("But maybe this is what you wanted, after all ...")

--- a/util/website.py
+++ b/util/website.py
@@ -1,11 +1,12 @@
 from __future__ import print_function
+from __future__ import absolute_import
 import os
 import paramiko
 import pysftp
 import sys
 
 from bs4 import BeautifulSoup
-from .log import merge_logs
+from util.log import merge_logs
 
 
 def parse_for_deps(filename):

--- a/util/website.py
+++ b/util/website.py
@@ -5,7 +5,7 @@ import pysftp
 import sys
 
 from bs4 import BeautifulSoup
-from log import merge_logs
+from .log import merge_logs
 
 def parse_for_deps(filename):
     """

--- a/util/website.py
+++ b/util/website.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import paramiko
 import pysftp
@@ -24,7 +25,7 @@ def parse_for_deps(filename):
         all_resources = map(lambda x: os.stat(x), external_links + external_scripts)
     except OSError as ex:
         if ex.errno == 2:
-            print "Missing dependency", ex
+            print("Missing dependency", ex)
             return []
         raise ex
 
@@ -33,7 +34,7 @@ def parse_for_deps(filename):
         readable_resources = map(lambda x: os.open(x, os.O_RDONLY), external_links + external_scripts)
         map(lambda x: os.close(x), readable_resources)
     except OSError as ex:
-        print "Unreadable dependency", ex
+        print("Unreadable dependency", ex)
         return []
 
     # It should be all good.
@@ -55,7 +56,7 @@ def verify_ssh_dir(auth_infos):
     we want to push data is either empty or contains at least a .htaccess and
     index.htm file
     """
-    print "Checking connection: %s@%s:%s (port %d)" % (auth_infos['ds_website_username'], auth_infos['ds_website_server_fqdn'], auth_infos['ds_website_server_root'], auth_infos['ds_website_server_port'])
+    print("Checking connection: %s@%s:%s (port %d)" % (auth_infos['ds_website_username'], auth_infos['ds_website_server_fqdn'], auth_infos['ds_website_server_root'], auth_infos['ds_website_server_port']))
 
     try:
         with get_ssh(auth_infos) as sftp:
@@ -64,13 +65,13 @@ def verify_ssh_dir(auth_infos):
                 if len(files) == 0 or (('.htaccess' in files) and ('index.htm' in files)):
                     return True
                 else:
-                    print "Invalid content for %s:" % (auth_infos['ds_website_server_root']), files
+                    print("Invalid content for %s:" % (auth_infos['ds_website_server_root']), files)
                     return False
     except paramiko.ssh_exception.AuthenticationException as ex:
-        print "Authentication error, please verify credentials"
+        print("Authentication error, please verify credentials")
         return False
     except IOError as ex:
-        print "Unable to read a file (private key or invalid path on server ?)", ex
+        print("Unable to read a file (private key or invalid path on server ?)", ex)
         return False
 
     # Should not be reached
@@ -93,23 +94,23 @@ def push_files_sftp(files, auth_infos):
                 # Create dirs if needed, they all should depend from the root
                 for dir in dirs:
                     if not sftp.isdir(dir):
-                        print "Creating directory", dir
+                        print("Creating directory", dir)
                         sftp.makedirs(dir)
                         created.append(dir)
 
                 # Push all files, chdir() for each
                 for fil in files:
                     with sftp.cd(os.path.dirname(fil)):
-                        print "Pushing", fil
+                        print("Pushing", fil)
                         sftp.put(fil)
                         pushed.append(fil)
 
         return pushed
     except paramiko.ssh_exception.AuthenticationException as ex:
-        print "Authentication error, please verify credentials"
+        print("Authentication error, please verify credentials")
         return False
     except IOError as ex:
-        print "Unable to read a file (private key or invalid path on server ?)", ex
+        print("Unable to read a file (private key or invalid path on server ?)", ex)
         return False
 
     # Should not be reached
@@ -145,12 +146,12 @@ def maybe_publish(file='index.htm'):
                try:
                    ssh_auth_infos[key] = int(os.environ.get(key))
                except TypeError as ex:
-                   print "WARNING:", "Keeping default SSH port value because of:", ex
+                   print("WARNING:", "Keeping default SSH port value because of:", ex)
 
     missing_env = filter(lambda x: len(str(ssh_auth_infos[x])) == 0, ssh_auth_infos.keys())
     if len(missing_env) > 0:
-        print "Not publishing, missing some required environment variables:", missing_env
-        print "But maybe this is what you wanted, after all ..."
+        print("Not publishing, missing some required environment variables:", missing_env)
+        print("But maybe this is what you wanted, after all ...")
         return False
 
     merge_logs("logs")
@@ -158,32 +159,32 @@ def maybe_publish(file='index.htm'):
     all_deps = parse_for_deps(file)
 
     if len(all_deps) == 0:
-        print "Problem during deps computation, aborting"
+        print("Problem during deps computation, aborting")
         return False
 
     if not verify_ssh_dir(ssh_auth_infos):
-        print "Problem during SSH directory verification, aborting"
+        print("Problem during SSH directory verification, aborting")
         return False
 
     all_files = [ file ] + all_deps
     uploaded = push_files_sftp(all_files, ssh_auth_infos)
     if len(uploaded) == 0:
-        print "Unable to upload anything"
+        print("Unable to upload anything")
         return False
     elif len(uploaded) != len(all_files):
-        print "Partial upload has been completed:"
-        print "all_files=", all_files
-        print "uploaded=", uploaded
+        print("Partial upload has been completed:")
+        print("all_files=", all_files)
+        print("uploaded=", uploaded)
     else:
-        print "Complete upload has been completed."
+        print("Complete upload has been completed.")
 
     return True
 
 # Support CLI invocation
 if __name__ == "__main__":
     if maybe_publish():
-        print "All good!"
+        print("All good!")
         sys.exit(0)
     else:
-        print "Error happened ..."
+        print("Error happened ...")
         sys.exit(1)


### PR DESCRIPTION
These are just mechanical/trivial changes to enable the first demo (ldc93s1) to run to completion under Python 3.6 (on Linux) as I wanted to see how it ran.

In theory we could do something smarter with the git revision and branch extraction, as currently we use a latin-1 decode (rather than the system native encoding) to get them to unicode form. Most of the rest of the changes are using modern prints and do a few list() calls around things that produce iterators under Python 3.x