### PR TITLE
Limit libdeepspeech -> tensorflow deps

### DIFF
--- a/native_client/BUILD
+++ b/native_client/BUILD
@@ -4,7 +4,7 @@ cc_library(
     name = "deepspeech",
     srcs = ["deepspeech.cc"],
     hdrs = ["deepspeech.h"],
-    deps = ["//tensorflow/core:tensorflow",
+    deps = ["//tensorflow/core:core",
             ":c_speech_features"]
 )
 


### PR DESCRIPTION
On my desktop, makes a `bazel build -c opt [...] //native_client:*`
after a `bazel clean` running in ~150 secs instead of 560 secs.

Fixes #475