### PR TITLE
Fix _example_queue in data_set_helpers to be example_queue as named in the importers

### DIFF
--- a/util/data_set_helpers.py
+++ b/util/data_set_helpers.py
@@ -44,7 +44,7 @@ class SwitchableDataSet(object):
         '''
         self._data_sets = data_sets
         self._sets = [data_sets.train, data_sets.dev, data_sets.test]
-        self._queues = [s._example_queue for s in self._sets]
+        self._queues = [s.example_queue for s in self._sets]
         self._queue_selector = tf.placeholder(tf.int32, name='Queue_Selector')
         self._queue = tf.QueueBase.from_list(self._queue_selector, self._queues)
         self._close_op = self._queue.close(cancel_pending_enqueues=True)


### PR DESCRIPTION
`util/data_set_helpers.py` `SwitchableDataSet.__init__`'s line:
`self._queues = [s._example_queue for s in self._sets]` seems to mean `.example_queue`, since that's what is defined in every importer.

Culprit traceback before this patch:
``` bash
[mike@self DeepSpeech] $ ./bin/run-ldc93s1.sh 
+ '[' '!' -f DeepSpeech.py ']'
+ python -u DeepSpeech.py --importer ldc93s1 --train_batch_size 1 --dev_batch_size 1 --test_batch_size 1 --n_hidden 494 --epoch 50
Traceback (most recent call last):
  File "DeepSpeech.py", line 1646, in <module>
    tf.app.run()
  File "/home/mike/projects/rnn/DeepSpeech/env/lib/python2.7/site-packages/tensorflow/python/platform/app.py", line 44, in run
    _sys.exit(main(_sys.argv[:1] + flags_passthrough))
  File "DeepSpeech.py", line 1609, in main
    train()
  File "DeepSpeech.py", line 1379, in train
    switchable_data_set = SwitchableDataSet(data_sets)
  File "/home/mike/projects/rnn/DeepSpeech/util/data_set_helpers.py", line 47, in __init__
    self._queues = [s._example_queue for s in self._sets]
AttributeError: 'DataSet' object has no attribute '_example_queue'
```