### PR TITLE
make run-ted.sh store to data instead of /data

### DIFF
--- a/bin/run-ted.sh
+++ b/bin/run-ted.sh
@@ -8,7 +8,6 @@ fi;
 
 python -u DeepSpeech.py \
   --importer ted \
-  --dataset_path data/LIUM/ \
   --train_batch_size 16 \
   --dev_batch_size 8 \
   --test_batch_size 8 \

--- a/bin/run-ted.sh
+++ b/bin/run-ted.sh
@@ -8,7 +8,7 @@ fi;
 
 python -u DeepSpeech.py \
   --importer ted \
-  --dataset_path /data/LIUM/ \
+  --dataset_path data/LIUM/ \
   --train_batch_size 16 \
   --dev_batch_size 8 \
   --test_batch_size 8 \


### PR DESCRIPTION
`bin/run-ted.sh` was referring to `/data/LIUM`, when what it means is `data/LIUM`.