### PR TITLE
Save absolute paths in dataset definition files

### DIFF
--- a/bin/import_fisher.py
+++ b/bin/import_fisher.py
@@ -139,7 +139,7 @@ def _split_wav_and_sentences(data_dir, trans_data, original_data, converted_data
                 new_wav_filesize = os.path.getsize(new_wav_file)
                 transcript = validate_label(segment["transcript"])
                 if transcript != None:
-                    files.append((new_wav_file, new_wav_filesize, transcript))
+                    files.append((os.path.abspath(new_wav_file), new_wav_filesize, transcript))
 
             # Close origAudios
             for origAudio in origAudios:

--- a/bin/import_ldc93s1.py
+++ b/bin/import_ldc93s1.py
@@ -21,7 +21,7 @@ def _download_and_preprocess_data(data_dir):
     with open(trans_file, "r") as fin:
         transcript = ' '.join(fin.read().strip().lower().split(' ')[2:]).replace('.', '')
 
-    df = pandas.DataFrame(data=[(local_file, os.path.getsize(local_file), transcript)],
+    df = pandas.DataFrame(data=[(os.path.abspath(local_file), os.path.getsize(local_file), transcript)],
                           columns=["wav_filename", "wav_filesize", "transcript"])
     df.to_csv(os.path.join(data_dir, "ldc93s1.csv"), index=False)
 

--- a/bin/import_librivox.py
+++ b/bin/import_librivox.py
@@ -171,7 +171,7 @@ def _convert_audio_and_split_sentences(extracted_dir, data_set, dest_dir):
                         Transformer().build(flac_file, wav_file)
                     wav_filesize = os.path.getsize(wav_file)
 
-                    files.append((wav_file, wav_filesize, transcript))
+                    files.append((os.path.abspath(wav_file), wav_filesize, transcript))
 
     return pandas.DataFrame(data=files, columns=["wav_filename", "wav_filesize", "transcript"])
 

--- a/bin/import_swb.py
+++ b/bin/import_swb.py
@@ -137,7 +137,7 @@ def _maybe_split_wav_and_sentences(data_dir, trans_data, original_data, converte
 
                 new_wav_filesize = os.path.getsize(new_wav_file)
                 transcript = segment["transcript"]
-                files.append((new_wav_file, new_wave_filesize, transcript))
+                files.append((os.path.abspath(new_wav_file), new_wave_filesize, transcript))
 
             # Close origAudio
             origAudio.close()

--- a/bin/import_ted.py
+++ b/bin/import_ted.py
@@ -131,7 +131,7 @@ def _maybe_split_dataset(extracted_dir, data_set):
                 _split_wav(origAudio, start_time, stop_time, new_wav_file)
 
             new_wav_filesize = path.getsize(new_wav_file)
-            files.append((new_wav_file, new_wav_filesize, stm_segment.transcript))
+            files.append((path.abspath(new_wav_file), new_wav_filesize, stm_segment.transcript))
 
         # Close origAudio
         origAudio.close()


### PR DESCRIPTION
This prevents weirdness when invoking DeepSpeech.py from a different folder than you ran the bin/import_* scripts.