### PR TITLE
Keep unsplit WAV files in the TED corpus

### DIFF
--- a/bin/import_ted.py
+++ b/bin/import_ted.py
@@ -136,9 +136,6 @@ def _maybe_split_dataset(extracted_dir, data_set):
         # Close origAudio
         origAudio.close()
 
-        # Remove wav_file
-        remove(wav_file)
-
     return pandas.DataFrame(data=files, columns=["wav_filename", "wav_filesize", "transcript"])
 
 def _split_wav(origAudio, start_time, stop_time, new_wav_file):


### PR DESCRIPTION
This lets us re-run the importer to re-create the CSV files, if we want to include punctuation or accents, for example. The downside is using more disk space than it's strictly necessary.