### PR TITLE
Avoid stripping during install

### DIFF
--- a/native_client/Makefile
+++ b/native_client/Makefile
@@ -58,9 +58,9 @@ debug: deepspeech
 
 install: deepspeech
 	install -d ${PREFIX}/lib
-	install -s -m 0644 ${TFDIR}/bazel-bin/tensorflow/libtensorflow.so ${PREFIX}/lib/
-	install -s -m 0644 ${TFDIR}/bazel-bin/native_client/libdeepspeech.so ${PREFIX}/lib/
-	install -s -m 0644 ${TFDIR}/bazel-bin/native_client/libdeepspeech_utils.so ${PREFIX}/lib/
+	install -m 0644 ${TFDIR}/bazel-bin/tensorflow/libtensorflow.so ${PREFIX}/lib/
+	install -m 0644 ${TFDIR}/bazel-bin/native_client/libdeepspeech.so ${PREFIX}/lib/
+	install -m 0644 ${TFDIR}/bazel-bin/native_client/libdeepspeech_utils.so ${PREFIX}/lib/
 	install -d ${PREFIX}/bin
 	install -m 0755 deepspeech ${PREFIX}/bin/
 


### PR DESCRIPTION
strip triggers issues on OSX:
/Library/Developer/CommandLineTools/usr/bin/strip: symbols referenced by
indirect symbol table entries that can't be stripped in:
/usr/local/lib/libtensorflow.so

Let's disable strip on install, we can always hand-strip if it is really
useful.

Fixes #635