### PR TITLE
Fix #363; Compare Bidirectional Recurrence vs Unidirectional Recurrence

### DIFF
--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -342,6 +342,88 @@ def variable_on_worker_level(name, shape, initializer):
     return var
 
 
+
+def UiRNN(batch_x, seq_length, dropout):
+    r'''
+    UiRNN - It is the unidirectional RNN model intented to compare the results against the BiRNN for benchmark variation
+    '''
+
+    # Input shape: [batch_size, n_steps, n_input + 2*n_input*n_context]
+    batch_x_shape = tf.shape(batch_x)
+
+    # Reshaping `batch_x` to a tensor with shape `[n_steps*batch_size, n_input + 2*n_input*n_context]`.
+    # This is done to prepare the batch for input into the first layer which expects a tensor of rank `2`.
+
+    # Permute n_steps and batch_size
+    batch_x = tf.transpose(batch_x, [1, 0, 2])
+    # Reshape to prepare input for first layer
+    batch_x = tf.reshape(batch_x, [-1, n_input + 2*n_input*n_context]) # (n_steps*batch_size, n_input + 2*n_input*n_context)
+
+    # The next three blocks will pass `batch_x` through three hidden layers with
+    # clipped RELU activation and dropout.
+
+    # 1st layer
+    b1 = variable_on_worker_level('b1', [n_hidden_1], tf.random_normal_initializer(stddev=FLAGS.b1_stddev))
+    h1 = variable_on_worker_level('h1', [n_input + 2*n_input*n_context, n_hidden_1], tf.contrib.layers.xavier_initializer(uniform=False))
+    layer_1 = tf.minimum(tf.nn.relu(tf.add(tf.matmul(batch_x, h1), b1)), FLAGS.relu_clip)
+    layer_1 = tf.nn.dropout(layer_1, (1.0 - dropout[0]))
+
+    # 2nd layer
+    b2 = variable_on_worker_level('b2', [n_hidden_2], tf.random_normal_initializer(stddev=FLAGS.b2_stddev))
+    h2 = variable_on_worker_level('h2', [n_hidden_1, n_hidden_2], tf.random_normal_initializer(stddev=FLAGS.h2_stddev))
+    layer_2 = tf.minimum(tf.nn.relu(tf.add(tf.matmul(layer_1, h2), b2)), FLAGS.relu_clip)
+    layer_2 = tf.nn.dropout(layer_2, (1.0 - dropout[1]))
+
+    # 3rd layer
+    b3 = variable_on_worker_level('b3', [n_hidden_3], tf.random_normal_initializer(stddev=FLAGS.b3_stddev))
+    h3 = variable_on_worker_level('h3', [n_hidden_2, n_hidden_3], tf.random_normal_initializer(stddev=FLAGS.h3_stddev))
+    layer_3 = tf.minimum(tf.nn.relu(tf.add(tf.matmul(layer_2, h3), b3)), FLAGS.relu_clip)
+    layer_3 = tf.nn.dropout(layer_3, (1.0 - dropout[2]))
+
+    # Now we create the forward LSTM units.
+    # Both of which have inputs of length `n_cell_dim` and bias `1.0` for the forget gate of the LSTM.
+
+    # Forward direction cell: (if else required for TF 1.0 and 1.1 compat)
+    lstm_fw_cell = tf.contrib.rnn.BasicLSTMCell(n_cell_dim, forget_bias=1.0, state_is_tuple=True) \
+                   if 'reuse' not in inspect.getargspec(tf.contrib.rnn.BasicLSTMCell.__init__).args else \
+                   tf.contrib.rnn.BasicLSTMCell(n_cell_dim, forget_bias=1.0, state_is_tuple=True, reuse=tf.get_variable_scope().reuse)
+    lstm_fw_cell = tf.contrib.rnn.DropoutWrapper(lstm_fw_cell,
+                                                input_keep_prob=1.0 - dropout[3],
+                                                output_keep_prob=1.0 - dropout[3],
+                                                seed=FLAGS.random_seed)
+
+    # `layer_3` is now reshaped into `[n_steps, batch_size, 2*n_cell_dim]`,
+    # as the LSTM BRNN expects its input to be of shape `[max_time, batch_size, input_size]`.
+    layer_3 = tf.reshape(layer_3, [-1, batch_x_shape[0], n_hidden_3])
+
+    # Now we feed `layer_3` into the LSTM RNN cell and obtain the LSTM Unidirectional RNN output.
+    lstm_cell_stack = tf.contrib.rnn.MultiRNNCell([lstm_fw_cell]*2, state_is_tuple=True)
+    outputs, output_states = tf.nn.dynamic_rnn(cell=lstm_cell_stack, inputs=layer_3, dtype=tf.float32, time_major=True, sequence_length=seq_length)
+    # Reshape outputs from two tensors each of shape [n_steps, batch_size, n_cell_dim]
+    # to a single tensor of shape [n_steps*batch_size, 2*n_cell_dim]
+    outputs = tf.concat(outputs, 2)
+    outputs = tf.reshape(outputs, [-1, n_cell_dim])
+
+    # Now we feed `outputs` to the fifth hidden layer with clipped RELU activation and dropout
+    b5 = variable_on_worker_level('b5', [n_hidden_5], tf.random_normal_initializer(stddev=FLAGS.b5_stddev))
+    h5 = variable_on_worker_level('h5', [(n_cell_dim), n_hidden_5], tf.random_normal_initializer(stddev=FLAGS.h5_stddev))
+    layer_5 = tf.minimum(tf.nn.relu(tf.add(tf.matmul(outputs, h5), b5)), FLAGS.relu_clip)
+    layer_5 = tf.nn.dropout(layer_5, (1.0 - dropout[5]))
+
+    # Now we apply the weight matrix `h6` and bias `b6` to the output of `layer_5`
+    # creating `n_classes` dimensional vectors, the logits.
+    b6 = variable_on_worker_level('b6', [n_hidden_6], tf.random_normal_initializer(stddev=FLAGS.b6_stddev))
+    h6 = variable_on_worker_level('h6', [n_hidden_5, n_hidden_6], tf.contrib.layers.xavier_initializer(uniform=False))
+    layer_6 = tf.add(tf.matmul(layer_5, h6), b6)
+
+    # Finally we reshape layer_6 from a tensor of shape [n_steps*batch_size, n_hidden_6]
+    # to the slightly more useful shape [n_steps, batch_size, n_hidden_6].
+    # Note, that this differs from the input in that it is time-major.
+    layer_6 = tf.reshape(layer_6, [-1, batch_x_shape[0], n_hidden_6])
+
+    # Output shape: [n_steps, batch_size, n_hidden_6]
+    return layer_6
+
 def BiRNN(batch_x, seq_length, dropout):
     r'''
     That done, we will define the learned variables, the weights and biases,


### PR DESCRIPTION
@kdavis-mozilla, @reuben : Can you have a look at this?

Changes Made: Replaced the lstm_cell consisting of forward and backward cell with the lstm_cell_stack consisting of 2 forward cells. The dimensionality of single 4096 units from the LSTM cell had been changed to 2 layer of 2048 units.

Dataset used: TED
Trainin time: 20:13:00
No. of Train epochs: 10
GPU instances used: 4 

Results:

Unidirectional Recurrence Case:

------------------------------------------------------------------------
I Test of Epoch 10 - WER: 0.448848, loss: 77.5554098553, mean edit distance: 0.209433
I --------------------------------------------------------------------------------
I WER: 0.333333, loss: 1.252548, mean edit distance: 0.076923
I  - src: "no im serious"
I  - res: "now im serious"
I --------------------------------------------------------------------------------
I WER: 0.333333, loss: 1.650417, mean edit distance: 0.076923
I  - src: "no im serious"
I  - res: "now im serious"
I --------------------------------------------------------------------------------
I WER: 0.333333, loss: 1.906622, mean edit distance: 0.076923
I  - src: "no im serious"
I  - res: "now im serious"
I --------------------------------------------------------------------------------
I WER: 0.333333, loss: 3.964957, mean edit distance: 0.222222
I  - src: "and i say"
I  - res: "and i save"
I --------------------------------------------------------------------------------
I WER: 0.500000, loss: 2.543439, mean edit distance: 0.100000
I  - src: "farms that"
I  - res: "forms that"
I --------------------------------------------------------------------------------
I WER: 0.500000, loss: 3.561996, mean edit distance: 0.100000
I  - src: "farms that"
I  - res: "forms that"
I --------------------------------------------------------------------------------
I WER: 1.000000, loss: 1.825124, mean edit distance: 0.333333
I  - src: "and"
I  - res: "nd"
I --------------------------------------------------------------------------------
I WER: 1.000000, loss: 2.459296, mean edit distance: 0.500000
I  - src: "so"
I  - res: "o"
I --------------------------------------------------------------------------------
I WER: 1.000000, loss: 2.511882, mean edit distance: 0.500000
I  - src: "so"
I  - res: "o"
I --------------------------------------------------------------------------------
I WER: 1.000000, loss: 3.144284, mean edit distance: 1.000000
I  - src: "so"
I  - res: ""
I --------------------------------------------------------------------------------
