### PR TITLE
Fix #361; Compare GRU's vs Current LSTM

### DIFF
--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -342,6 +342,80 @@ def variable_on_worker_level(name, shape, initializer):
     return var
 
 
+def GRuRNN(batch_x, seq_length, dropout):
+    r'''
+    RNN with GRU Cell to compare the results against Current LSTM cell
+    '''
+
+    # Input shape: [batch_size, n_steps, n_input + 2*n_input*n_context]
+    batch_x_shape = tf.shape(batch_x)
+
+    # Reshaping `batch_x` to a tensor with shape `[n_steps*batch_size, n_input + 2*n_input*n_context]`.
+    # This is done to prepare the batch for input into the first layer which expects a tensor of rank `2`.
+
+    # Permute n_steps and batch_size
+    batch_x = tf.transpose(batch_x, [1, 0, 2])
+    # Reshape to prepare input for first layer
+    batch_x = tf.reshape(batch_x, [-1, n_input + 2*n_input*n_context]) # (n_steps*batch_size, n_input + 2*n_input*n_context)
+
+    # The next three blocks will pass `batch_x` through three hidden layers with
+    # clipped RELU activation and dropout.
+
+    # 1st layer
+    b1 = variable_on_worker_level('b1', [n_hidden_1], tf.random_normal_initializer(stddev=FLAGS.b1_stddev))
+    h1 = variable_on_worker_level('h1', [n_input + 2*n_input*n_context, n_hidden_1], tf.contrib.layers.xavier_initializer(uniform=False))
+    layer_1 = tf.minimum(tf.nn.relu(tf.add(tf.matmul(batch_x, h1), b1)), FLAGS.relu_clip)
+    layer_1 = tf.nn.dropout(layer_1, (1.0 - dropout[0]))
+
+    # 2nd layer
+    b2 = variable_on_worker_level('b2', [n_hidden_2], tf.random_normal_initializer(stddev=FLAGS.b2_stddev))
+    h2 = variable_on_worker_level('h2', [n_hidden_1, n_hidden_2], tf.random_normal_initializer(stddev=FLAGS.h2_stddev))
+    layer_2 = tf.minimum(tf.nn.relu(tf.add(tf.matmul(layer_1, h2), b2)), FLAGS.relu_clip)
+    layer_2 = tf.nn.dropout(layer_2, (1.0 - dropout[1]))
+
+    # 3rd layer
+    b3 = variable_on_worker_level('b3', [n_hidden_3], tf.random_normal_initializer(stddev=FLAGS.b3_stddev))
+    h3 = variable_on_worker_level('h3', [n_hidden_2, n_hidden_3], tf.random_normal_initializer(stddev=FLAGS.h3_stddev))
+    layer_3 = tf.minimum(tf.nn.relu(tf.add(tf.matmul(layer_2, h3), b3)), FLAGS.relu_clip)
+    layer_3 = tf.nn.dropout(layer_3, (1.0 - dropout[2]))
+
+    # Now we create the GRU Cell.
+
+    # GRU Cell
+    gru_cell = tf.contrib.rnn.GRUCell(num_units=n_cell_dim) \
+               if 'reuse' not in inspect.getargspec(tf.contrib.rnn.GRUCell.__init__).args else \
+               tf.contrib.rnn.GRUCell(num_units=n_cell_dim, reuse=tf.get_variable_scope().reuse)
+    # `layer_3` is now reshaped into `[n_steps, batch_size, n_cell_dim]`,
+    # as the GRU Cell RNN expects its input to be of shape `[max_time, batch_size, input_size]`.
+    layer_3 = tf.reshape(layer_3, [-1, batch_x_shape[0], n_hidden_3])
+
+    # Now we feed `layer_3` into the GRU RNN cell and obtain the GRU RNN output.
+    outputs, output_states = tf.nn.dynamic_rnn(cell=gru_cell, inputs=layer_3, dtype=tf.float32, time_major=True, sequence_length=seq_length)
+    # Reshape outputs from two tensors each of shape [n_steps, batch_size, n_cell_dim]
+    # to a single tensor of shape [n_steps*batch_size, n_cell_dim]
+    outputs = tf.concat(outputs, 2)
+    outputs = tf.reshape(outputs, [-1, n_cell_dim])
+
+    # Now we feed `outputs` to the fifth hidden layer with clipped RELU activation and dropout
+    b5 = variable_on_worker_level('b5', [n_hidden_5], tf.random_normal_initializer(stddev=FLAGS.b5_stddev))
+    h5 = variable_on_worker_level('h5', [( n_cell_dim), n_hidden_5], tf.random_normal_initializer(stddev=FLAGS.h5_stddev))
+    layer_5 = tf.minimum(tf.nn.relu(tf.add(tf.matmul(outputs, h5), b5)), FLAGS.relu_clip)
+    layer_5 = tf.nn.dropout(layer_5, (1.0 - dropout[5]))
+
+    # Now we apply the weight matrix `h6` and bias `b6` to the output of `layer_5`
+    # creating `n_classes` dimensional vectors, the logits.
+    b6 = variable_on_worker_level('b6', [n_hidden_6], tf.random_normal_initializer(stddev=FLAGS.b6_stddev))
+    h6 = variable_on_worker_level('h6', [n_hidden_5, n_hidden_6], tf.contrib.layers.xavier_initializer(uniform=False))
+    layer_6 = tf.add(tf.matmul(layer_5, h6), b6)
+
+    # Finally we reshape layer_6 from a tensor of shape [n_steps*batch_size, n_hidden_6]
+    # to the slightly more useful shape [n_steps, batch_size, n_hidden_6].
+    # Note, that this differs from the input in that it is time-major.
+    layer_6 = tf.reshape(layer_6, [-1, batch_x_shape[0], n_hidden_6])
+
+    # Output shape: [n_steps, batch_size, n_hidden_6]
+    return layer_6
+
 def BiRNN(batch_x, seq_length, dropout):
     r'''
     That done, we will define the learned variables, the weights and biases,


### PR DESCRIPTION
**Note: This branch is not intended for merging into the master branch. It is simply a part of benchmark variation comparison. Hence, the branch name is prefixed with test_**

Test with GRU cell instead of Current LSTM cell

GRU cell results:

Dataset used: TED
Training Time: 8:13:07 (Lower than usual which is expected as compared to LSTMs)
No. of Train epochs: 10
GPU instances used: 4

I FINISHED Optimization - training time: 8:13:07
I Test of Epoch 10 - WER: 0.530035, loss: 94.745821317, mean edit distance: 0.254709
I --------------------------------------------------------------------------------
I WER: 0.200000, loss: 5.857036, mean edit distance: 0.050000
I  - src: "to do that dont look"
I  - res: "o do that dont look"
I --------------------------------------------------------------------------------
I WER: 0.333333, loss: 4.066966, mean edit distance: 0.111111
I  - src: "and i say"
I  - res: "and i saw"
I --------------------------------------------------------------------------------
I WER: 0.333333, loss: 4.303623, mean edit distance: 0.090909
I  - src: "yes he said"
I  - res: "yes the said"
I --------------------------------------------------------------------------------
I WER: 0.333333, loss: 5.691000, mean edit distance: 0.222222
I  - src: "and i say"
I  - res: "and i save"
I --------------------------------------------------------------------------------
I WER: 0.500000, loss: 4.931426, mean edit distance: 0.285714
I  - src: "sort of"
I  - res: "sort a"
I --------------------------------------------------------------------------------
I WER: 0.500000, loss: 5.437888, mean edit distance: 0.133333
I  - src: "not intensively"
I  - res: "not intensely"
I --------------------------------------------------------------------------------
I WER: 1.000000, loss: 1.898744, mean edit distance: 0.333333
I  - src: "and"
I  - res: "nd"
I --------------------------------------------------------------------------------
I WER: 1.000000, loss: 2.118078, mean edit distance: 0.500000
I  - src: "so"
I  - res: "of"
I --------------------------------------------------------------------------------
I WER: 1.000000, loss: 2.586474, mean edit distance: 0.500000
I  - src: "so"
I  - res: "o"
I --------------------------------------------------------------------------------
I WER: 1.000000, loss: 3.953010, mean edit distance: 0.500000
I  - src: "so"
I  - res: "o"
I --------------------------------------------------------------------------------


Will post the results from Current LSTM cell test run after a couple of more benchmark variation algorithm test runs.

