### PR TITLE
fix bug in feeding.py

### DIFF
--- a/util/feeding.py
+++ b/util/feeding.py
@@ -90,7 +90,7 @@ class DataSet(object):
             if self.files is None:
                 self.files = file
             else:
-                self.files = files.append(file)
+                self.files = self.files.append(file)
         self.files = self.files.sort_values(by="wav_filesize", ascending=ascending) \
                          .ix[:, ["wav_filename", "transcript"]] \
                          .values[skip:]


### PR DESCRIPTION
There was a small bug in feeding.py where i got
 
`NameError: global name 'files' is not defined`

when running run-librivox.sh