### PR TITLE
Import TIMIT dataset

### DIFF
--- a/bin/import_timit.py
+++ b/bin/import_timit.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+
+# SCRIPT AUTHOR: Rob Smith
+
+'''
+    NAME    : LDC TIMIT Dataset
+    URL     : https://catalog.ldc.upenn.edu/ldc93s1
+    HOURS   : 5
+    TYPE    : Read - English
+    AUTHORS : Garofolo, John, et al.
+    TYPE    : LDC Membership
+    LICENCE : LDC User Agreement
+
+'''
+
+import errno
+import os
+import sys
+import tarfile
+from os import path
+import fnmatch
+import pandas as pd
+import subprocess
+
+def clean(word):
+    ## LC ALL & strip fullstop, comma and semi-colon which are not required
+    new = word.lower().replace('.', '')
+    new = new.replace(',', '')
+    new = new.replace(';', '')
+    new = new.replace('"', '')
+    new = new.replace('!', '')
+    new = new.replace('?', '')
+    new = new.replace(':', '')
+    new = new.replace('-', '')
+    return new
+
+def _preprocess_data(args):
+
+    # Assume data is downloaded from LDC - https://catalog.ldc.upenn.edu/ldc93s1
+
+    datapath = args
+    target = path.join(datapath,"TIMIT")
+    print("Checking to see if data has already been extracted in given argument: %s", target)
+
+    if not path.isdir(target):
+        print("Could not find extracted data, trying to find: TIMIT-LDC93S1.tgz in: ", datapath)
+        filepath = path.join(datapath, "TIMIT-LDC93S1.tgz")
+        if path.isfile(filepath):
+            print("File found, extracting")
+            #extract
+            tar = tarfile.open(filepath)
+            tar.extractall(target)
+            tar.close()
+        else:
+            strerror = "File not found"
+            raise IOError(errno, strerror, filepath)
+    else:
+        #is path therefore continue
+        print("Found extracted data in: ", target)
+
+    print("Preprocessing data")
+    # WE CONVERT THE WAV (NIST sphere format) into MSOFT WAV
+    # Note on Windows and Mac have case conflict (.WAV == .wav) creates _rif.wav as the new .wav file
+    for root, dirnames, filenames in os.walk(target):
+        for filename in fnmatch.filter(filenames, "*.WAV"):
+            sph_file = os.path.join(root, filename)
+            wav_file = os.path.join(root, filename)[:-4] + "_rif.wav"
+            print("converting {} to {}".format(sph_file, wav_file))
+            subprocess.check_call(["sox", sph_file, wav_file])
+
+    print("Preprocessing Complete")
+    print("Building CSVs")
+
+    # LISTS TO BUILD CSV files
+    train_list_wavs, train_list_trans, train_list_size = [], [], []
+    test_list_wavs, test_list_trans, test_list_size = [], [], []
+
+    for root, dirnames, filenames in os.walk(target):
+        for filename in fnmatch.filter(filenames, "*_rif.wav"):
+
+            full_wav = os.path.join(root, filename)
+            wav_filesize = path.getsize(full_wav)
+
+            # need to remove _rif.wav (8chars) then add .TXT
+            trans_file = full_wav[:-8] + ".TXT"
+            with open(trans_file, "r") as f:
+                for line in f:
+                    split = line.split()
+                    start = split[0]
+                    end = split[1]
+                    t_list = split[2:]
+                    trans = ""
+
+                    for t in t_list:
+                        trans = trans + " " + clean(t)
+
+            if 'train' in full_wav.lower():
+                train_list_wavs.append(full_wav)
+                train_list_trans.append(trans)
+                train_list_size.append(wav_filesize)
+            elif 'test' in full_wav.lower():
+                test_list_wavs.append(full_wav)
+                test_list_trans.append(trans)
+                test_list_size.append(wav_filesize)
+            else:
+                raise IOError
+
+    a = {'wav_filename': train_list_wavs,
+         'wav_filesize': train_list_size,
+         'transcript': train_list_trans
+         }
+
+    c = {'wav_filename': test_list_wavs,
+         'wav_filesize': test_list_size,
+         'transcript': test_list_trans,
+         }
+
+    all = {'wav_filename': train_list_wavs + test_list_wavs,
+          'wav_filesize': train_list_size + test_list_size,
+          'transcript': train_list_trans + test_list_trans,
+          }
+
+    df_all = pd.DataFrame(all, columns=['wav_filename', 'wav_filesize', 'transcript'], dtype=int)
+    df_train = pd.DataFrame(a, columns=['wav_filename', 'wav_filesize', 'transcript'], dtype=int)
+    df_test = pd.DataFrame(c, columns=['wav_filename', 'wav_filesize', 'transcript'], dtype=int)
+
+    df_all.to_csv(target+"/timit_all.csv", sep=',', header=True, index=False, encoding='ascii')
+    df_train.to_csv(target+"/timit_train.csv", sep=',', header=True, index=False, encoding='ascii')
+    df_test.to_csv(target+"/timit_test.csv", sep=',', header=True, index=False, encoding='ascii')
+
+if __name__ == "__main__":
+    _preprocess_data(sys.argv[1])
+    print("Completed")

--- a/bin/import_timit.py
+++ b/bin/import_timit.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-# SCRIPT AUTHOR: Rob Smith
-
 '''
     NAME    : LDC TIMIT Dataset
     URL     : https://catalog.ldc.upenn.edu/ldc93s1
@@ -10,20 +8,19 @@
     AUTHORS : Garofolo, John, et al.
     TYPE    : LDC Membership
     LICENCE : LDC User Agreement
-
 '''
 
 import errno
 import os
+from os import path
 import sys
 import tarfile
-from os import path
 import fnmatch
 import pandas as pd
 import subprocess
 
 def clean(word):
-    ## LC ALL & strip fullstop, comma and semi-colon which are not required
+    # LC ALL & strip punctuation which are not required
     new = word.lower().replace('.', '')
     new = new.replace(',', '')
     new = new.replace(';', '')
@@ -39,7 +36,7 @@ def _preprocess_data(args):
     # Assume data is downloaded from LDC - https://catalog.ldc.upenn.edu/ldc93s1
 
     datapath = args
-    target = path.join(datapath,"TIMIT")
+    target = path.join(datapath, "TIMIT")
     print("Checking to see if data has already been extracted in given argument: %s", target)
 
     if not path.isdir(target):
@@ -47,20 +44,21 @@ def _preprocess_data(args):
         filepath = path.join(datapath, "TIMIT-LDC93S1.tgz")
         if path.isfile(filepath):
             print("File found, extracting")
-            #extract
             tar = tarfile.open(filepath)
             tar.extractall(target)
             tar.close()
         else:
+            print("File should be downloaded from LDC and placed at:", filepath)
             strerror = "File not found"
             raise IOError(errno, strerror, filepath)
+
     else:
-        #is path therefore continue
+        # is path therefore continue
         print("Found extracted data in: ", target)
 
     print("Preprocessing data")
-    # WE CONVERT THE WAV (NIST sphere format) into MSOFT WAV
-    # Note on Windows and Mac have case conflict (.WAV == .wav) creates _rif.wav as the new .wav file
+    # We convert the .WAV (NIST sphere format) into MSOFT .wav
+    # creates _rif.wav as the new .wav file
     for root, dirnames, filenames in os.walk(target):
         for filename in fnmatch.filter(filenames, "*.WAV"):
             sph_file = os.path.join(root, filename)
@@ -71,7 +69,7 @@ def _preprocess_data(args):
     print("Preprocessing Complete")
     print("Building CSVs")
 
-    # LISTS TO BUILD CSV files
+    # Lists to build CSV files
     train_list_wavs, train_list_trans, train_list_size = [], [], []
     test_list_wavs, test_list_trans, test_list_size = [], [], []
 
@@ -112,12 +110,12 @@ def _preprocess_data(args):
 
     c = {'wav_filename': test_list_wavs,
          'wav_filesize': test_list_size,
-         'transcript': test_list_trans,
+         'transcript': test_list_trans
          }
 
     all = {'wav_filename': train_list_wavs + test_list_wavs,
           'wav_filesize': train_list_size + test_list_size,
-          'transcript': train_list_trans + test_list_trans,
+          'transcript': train_list_trans + test_list_trans
           }
 
     df_all = pd.DataFrame(all, columns=['wav_filename', 'wav_filesize', 'transcript'], dtype=int)

--- a/bin/import_timit.py
+++ b/bin/import_timit.py
@@ -84,7 +84,6 @@ def _preprocess_data(args):
 
     for root, dirnames, filenames in os.walk(target):
         for filename in fnmatch.filter(filenames, "*_rif.wav"):
-
             full_wav = os.path.join(root, filename)
             wav_filesize = path.getsize(full_wav)
 
@@ -103,7 +102,7 @@ def _preprocess_data(args):
 
             # if ignoreSAsentences we only want those without SA in the name
             # OR
-            # if not ignoreSAsentences we want all
+            # if not ignoreSAsentences we want all to be added
             if (ignoreSASentences and not ('SA' in os.path.basename(full_wav))) or (not ignoreSASentences):
                 if 'train' in full_wav.lower():
                     train_list_wavs.append(full_wav)

--- a/bin/import_timit.py
+++ b/bin/import_timit.py
@@ -35,6 +35,15 @@ def _preprocess_data(args):
 
     # Assume data is downloaded from LDC - https://catalog.ldc.upenn.edu/ldc93s1
 
+    # SA sentences are repeated throughout by each speaker therefore can be removed for ASR as they will affect WER
+    ignoreSASentences = True
+
+    if ignoreSASentences:
+        print("Using recommended ignore SA sentences")
+        print("Ignoring SA sentences (2 x sentences which are repeated by all speakers)")
+    else:
+        print("Using unrecommended setting to include SA sentences")
+
     datapath = args
     target = path.join(datapath, "TIMIT")
     print("Checking to see if data has already been extracted in given argument: %s", target)
@@ -92,16 +101,20 @@ def _preprocess_data(args):
                     for t in t_list:
                         trans = trans + " " + clean(t)
 
-            if 'train' in full_wav.lower():
-                train_list_wavs.append(full_wav)
-                train_list_trans.append(trans)
-                train_list_size.append(wav_filesize)
-            elif 'test' in full_wav.lower():
-                test_list_wavs.append(full_wav)
-                test_list_trans.append(trans)
-                test_list_size.append(wav_filesize)
-            else:
-                raise IOError
+            # if ignoreSAsentences we only want those without SA in the name
+            # OR
+            # if not ignoreSAsentences we want all
+            if (ignoreSASentences and not ('SA' in os.path.basename(full_wav))) or (not ignoreSASentences):
+                if 'train' in full_wav.lower():
+                    train_list_wavs.append(full_wav)
+                    train_list_trans.append(trans)
+                    train_list_size.append(wav_filesize)
+                elif 'test' in full_wav.lower():
+                    test_list_wavs.append(full_wav)
+                    test_list_trans.append(trans)
+                    test_list_size.append(wav_filesize)
+                else:
+                    raise IOError
 
     a = {'wav_filename': train_list_wavs,
          'wav_filesize': train_list_size,

--- a/bin/run-timit.sh
+++ b/bin/run-timit.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -xe
+if [ ! -f DeepSpeech.py ]; then
+    echo "Please make sure you run this from DeepSpeech's top level directory."
+    exit 1
+fi;
+
+if [ ! -f "data/TIMIT/timit_train.csv" ]; then
+    echo "Trying to preprocess TIMIT data, saving in ./data/TIMIT"
+    python -u bin/import_timit.py ./data/
+fi;
+
+if [ -d "${COMPUTE_KEEP_DIR}" ]; then
+    checkpoint_dir=$COMPUTE_KEEP_DIR
+else
+    checkpoint_dir=$(python -c 'from xdg import BaseDirectory as xdg; print(xdg.save_data_path("deepspeech/timit"))')
+fi
+
+python -u DeepSpeech.py \
+  --train_files data/TIMIT/timit_train.csv \
+  --dev_files data/TIMIT/timit_test.csv \
+  --test_files data/TIMIT/timit_test.csv \
+  --train_batch_size 8 \
+  --dev_batch_size 8 \
+  --test_batch_size 8 \
+  --n_hidden 494 \
+  --epoch 50 \
+  --checkpoint_dir "$checkpoint_dir" \
+  "$@"


### PR DESCRIPTION
Hi,

I created a TIMIT preparation script for everything (excluding the download, as it's LDC). It was one of the few, very well used, paid LDC datasets that I had at my disposal. It's only small, with around 5 hours worth of audio and has 630 speakers with 10 types of specially crafted sentences, designed to test ASR systems. 

"The TIMIT corpus of read speech is designed to provide speech data for acoustic-phonetic studies and for the development and evaluation of automatic speech recognition systems. TIMIT contains broadband recordings of 630 speakers of eight major dialects of American English, each reading ten phonetically rich sentences. The TIMIT corpus includes time-aligned orthographic, phonetic and word transcriptions as well as a 16-bit, 16kHz speech waveform file for each utterance."

More details, such as sentence distribution/gender, can be found [here](https://catalog.ldc.upenn.edu/ldc93s1). Traditionally papers have compared PER using TIMIT but there's no reason why WER cannot be compared also.

**What's included in this PR?**
1. import_timit.py - extracts, processes and outputs the required train/test CSV files 
2. run-timit.sh - will run TIMIT with basic defaults (similarly to the other run scripts)

**Has it been tested?**
Yes - I have tested with Ubuntu 16.04 using python 2.7. It extracts, preprocesses builds the CSVs and runs as expected. 
