### PR TITLE
Fix gzip format error to uncompress tar.xz via tc.py

### DIFF
--- a/util/tc.py
+++ b/util/tc.py
@@ -62,4 +62,4 @@ if __name__ == '__main__':
 
     maybe_download_tc(target_dir=target_dir, tc_url=get_tc_url(arch_string))
 
-    subprocess.check_call(['tar', 'xvzf', os.path.join(target_dir, 'native_client.tar.xz'), '-C', target_dir])
+    subprocess.check_call(['tar', 'xvf', os.path.join(target_dir, 'native_client.tar.xz'), '-C', target_dir])


### PR DESCRIPTION
Native_client file is in .tar.xz format so extracting with tar -xzvf will give error "gzip: stdin: not in gzip format"