### PR TITLE
Add one shot inference mode and make sure test-only runs don't change the checkpoint state

### DIFF
--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -1531,7 +1531,7 @@ def train(server=None):
         hooks.append(tf.train.SummarySaverHook(save_secs=FLAGS.summary_secs, output_dir=FLAGS.summary_dir, summary_op=merge_all_summaries_op))
 
     # Hook wih number of checkpoint files to save in checkpoint_dir
-    if FLAGS.max_to_keep > 0:
+    if FLAGS.train and FLAGS.max_to_keep > 0:
         saver = tf.train.Saver(max_to_keep=FLAGS.max_to_keep)
         hooks.append(tf.train.CheckpointSaverHook(checkpoint_dir=FLAGS.checkpoint_dir, save_secs=FLAGS.checkpoint_secs, saver=saver))
 
@@ -1543,7 +1543,7 @@ def train(server=None):
                                                is_chief=is_chief,
                                                hooks=hooks,
                                                checkpoint_dir=FLAGS.checkpoint_dir,
-                                               save_checkpoint_secs=FLAGS.checkpoint_secs,
+                                               save_checkpoint_secs=FLAGS.checkpoint_secs if FLAGS.train else None,
                                                config=session_config) as session:
             try:
                 if is_chief:

--- a/util/audio.py
+++ b/util/audio.py
@@ -1,5 +1,8 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
+
 import scipy.io.wavfile as wav
+import sys
+
 try:
     from deepspeech.utils import audioToInputVector
 except ImportError:
@@ -13,10 +16,10 @@ except ImportError:
     def audioToInputVector(audio, fs, numcep, numcontext):
         if DeprecationWarning.displayed is not True:
             DeprecationWarning.displayed = True
-            print('------------------------------------------------------------------------')
-            print('WARNING: libdeepspeech failed to load, resorting to deprecated code')
-            print('         Refer to README.md for instructions on installing libdeepspeech')
-            print('------------------------------------------------------------------------')
+            print('------------------------------------------------------------------------', file=sys.stderr)
+            print('WARNING: libdeepspeech failed to load, resorting to deprecated code',      file=sys.stderr)
+            print('         Refer to README.md for instructions on installing libdeepspeech', file=sys.stderr)
+            print('------------------------------------------------------------------------', file=sys.stderr)
 
         # Get mfcc coefficients
         features = mfcc(audio, samplerate=fs, numcep=numcep)


### PR DESCRIPTION
This makes sure DeepSpeech.py is usable for running test epochs on an externally obtained checkpoint without changing its state, and also a one-shot inference mode that takes in an audio path and does inference on it (again, based on the checkpoint).

The commit moving the deprecation warning to stderr is just so that the only stdout output in one-shot mode is the inference result itself.

Initially I tried hooking into the existing training setup by creating a new "one-shot" type of `Job` and using that with the coordinator, but that only lead to frustration debugging a thousand problems. Since all of that code is changing soon anyway, I decided to put this code on an earlier level of the execution, next to `train()` and `export()`.