### PR TITLE
Remove 'runs/0' references in artifacts path

### DIFF
--- a/taskcluster/darwin-opt-base.tyml
+++ b/taskcluster/darwin-opt-base.tyml
@@ -40,7 +40,7 @@ payload:
     in:
       TENSORFLOW_BUILD_ARTIFACT: ${build.tensorflow}
       SUMMARIZE_GRAPH_BINARY: ${build.summarize_graph}
-      DEEPSPEECH_TEST_MODEL: https://queue.taskcluster.net/v1/task/${training}/runs/0/artifacts/public/output_graph.pb
+      DEEPSPEECH_TEST_MODEL: https://queue.taskcluster.net/v1/task/${training}/artifacts/public/output_graph.pb
       DEEPSPEECH_PROD_MODEL: https://github.com/lissyx/DeepSpeech/releases/download/0.0.2/tc-fake-prod.988_e120.LSTM.ldc93s1.pb
 
   # There is no VM yet running tasks on OSX

--- a/taskcluster/linux-opt-base.tyml
+++ b/taskcluster/linux-opt-base.tyml
@@ -35,7 +35,7 @@ payload:
     in:
       TENSORFLOW_BUILD_ARTIFACT: ${build.tensorflow}
       SUMMARIZE_GRAPH_BINARY: ${build.summarize_graph}
-      DEEPSPEECH_TEST_MODEL: https://queue.taskcluster.net/v1/task/${training}/runs/0/artifacts/public/output_graph.pb
+      DEEPSPEECH_TEST_MODEL: https://queue.taskcluster.net/v1/task/${training}/artifacts/public/output_graph.pb
       DEEPSPEECH_PROD_MODEL: https://github.com/lissyx/DeepSpeech/releases/download/0.0.2/tc-fake-prod.988_e120.LSTM.ldc93s1.pb
 
   command:

--- a/taskcluster/test-linux-opt-base.tyml
+++ b/taskcluster/test-linux-opt-base.tyml
@@ -28,9 +28,9 @@ then:
         linux_amd64_ctc: { $eval: as_slugid("linux-amd64-ctc-opt") }
       in:
         TENSORFLOW_WHEEL: https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.master.cpu/artifacts/public/tensorflow_warpctc-1.3.0rc0-cp27-cp27mu-linux_x86_64.whl
-        DEEPSPEECH_ARTIFACTS_ROOT: https://queue.taskcluster.net/v1/task/${linux_amd64_build}/runs/0/artifacts/public
-        DEEPSPEECH_LIBCTC: https://queue.taskcluster.net/v1/task/${linux_amd64_ctc}/runs/0/artifacts/public/decoder.tar.xz
-        DEEPSPEECH_TEST_MODEL: https://queue.taskcluster.net/v1/task/${training}/runs/0/artifacts/public/output_graph.pb
+        DEEPSPEECH_ARTIFACTS_ROOT: https://queue.taskcluster.net/v1/task/${linux_amd64_build}/artifacts/public
+        DEEPSPEECH_LIBCTC: https://queue.taskcluster.net/v1/task/${linux_amd64_ctc}/artifacts/public/decoder.tar.xz
+        DEEPSPEECH_TEST_MODEL: https://queue.taskcluster.net/v1/task/${training}/artifacts/public/output_graph.pb
 
     command:
       - "/bin/bash"


### PR DESCRIPTION
Generated with:
$ sed -ri 's|runs/0/||g' taskcluster/*.tyml

Fixes #933