### PR TITLE
Revert "Added language model with apostrophe"

### DIFF
--- a/data/lm/lm.binary
+++ b/data/lm/lm.binary
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d15d206a4d9fa71875c0e4c09a254c044613e0dcacda35edcbdf52d430d41e11
-size 927811336
+oid sha256:0ef71a9dca85a30dbfbfa4ff4303f9e2e289c2018c1a627174dadd37351a4517
+size 1601028778


### PR DESCRIPTION
This reverts commit c5db7d1f71556e63805c3ab57a4b6baa3b8ca294 and fixed #965  