### PR TITLE
Match filenames in release 0.1.0 (output_graph.pb).

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ Once everything is installed you can then use the `deepspeech` binary to do spee
 
 ```bash
 pip install deepspeech
-deepspeech models/output_model.pb my_audio_file.wav models/alphabet.txt
+deepspeech models/output_graph.pb my_audio_file.wav models/alphabet.txt
 ```
 
 Alternatively, quicker inference (The realtime factor on a GeForce GTX 1070 is about 0.44.) can be performed using a supported NVIDIA GPU on Linux. (See the release notes to find which GPU's are supported.) This is done by instead installing the GPU specific package:
 
 ```bash
 pip install deepspeech-gpu
-deepspeech models/output_model.pb my_audio_file.wav models/alphabet.txt
+deepspeech models/output_graph.pb my_audio_file.wav models/alphabet.txt
 ```
 
 See the output of `deepspeech -h` for more information on the use of `deepspeech`. (If you experience problems running `deepspeech`, please check [required runtime dependencies](native_client/README.md#required-dependencies)).
@@ -133,7 +133,7 @@ In both cases, it should take care of installing all the required dependencies. 
 Note: the following command assumes you [downloaded the pre-trained model](#getting-the-pre-trained-model).
 
 ```bash
-deepspeech models/output_model.pb my_audio_file.wav models/alphabet.txt models/lm.binary models/trie
+deepspeech models/output_graph.pb my_audio_file.wav models/alphabet.txt models/lm.binary models/trie
 ```
 
 The last two arguments are optional, and represent a language model.
@@ -159,7 +159,7 @@ This will download `native_client.tar.xz` which includes the deepspeech binary a
 Note: the following command assumes you [downloaded the pre-trained model](#getting-the-pre-trained-model).
 
 ```bash
-./deepspeech models/output_model.pb audio_input.wav models/alphabet.txt models/lm.binary models/trie
+./deepspeech models/output_graph.pb audio_input.wav models/alphabet.txt models/lm.binary models/trie
 ```
 
 


### PR DESCRIPTION
If you run the original commands in the README, with the sample audio files, you get a segfault:

```
$ deepspeech models/output_graph.pb audio/2830-3980-0043.wav models/alphabet.txt models/lm.binary models/trie
Loading model from file models/output_model.pb
Not found: models/output_model.pb; No such file or directory
Loaded model in 0.001s.
Loading language model from files models/lm.binary models/trie
Loaded language model in 0.816s.
Running inference.
Segmentation fault
```

Fortunately the cause is simple, the README referred to models/output_model.pb, while the actual filename in deepspeech-0.1.0-models.tar.gz is models/output_graph.pb. It confused me for a moment at first since I thought the model might well be separate from the graph. Also, perhaps deepspeech should exit more gracefully in this case. It's probably just a NULL pointer check. Cheers.