### PR TITLE
Pass string rather than exception object to log_error()

### DIFF
--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -1743,8 +1743,8 @@ def export():
                                       output_graph_path, clear_devices, '')
 
             log_info('Models exported at %s' % (FLAGS.export_dir))
-        except RuntimeError:
-            log_error(sys.exc_info()[1])
+        except RuntimeError as e:
+            log_error(str(e))
 
 
 def do_single_file_inference(input_file_path):


### PR DESCRIPTION
Fixes https://github.com/mozilla/DeepSpeech/issues/1016

Steps to reproduce the bug:
```shell
mkdir models
./bin/run-ldc93s1.sh --decoder_library_path decode/libctc_decoder_with_kenlm.so --export_dir models
# Second time
./bin/run-ldc93s1.sh --decoder_library_path decode/libctc_decoder_with_kenlm.so --export_dir models
...skip...
Traceback (most recent call last):
  File "DeepSpeech.py", line 1830, in <module>
    tf.app.run()
  File "/usr/local/lib/python2.7/site-packages/tensorflow/python/platform/app.py", line 48, in run
    _sys.exit(main(_sys.argv[:1] + flags_passthrough))
  File "DeepSpeech.py", line 1821, in main
    export()
  File "DeepSpeech.py", line 1747, in export
    log_error(sys.exc_info()[1])
  File "DeepSpeech.py", line 349, in log_error
    prefix_print('E ', message)
  File "DeepSpeech.py", line 329, in prefix_print
    print(prefix + ('\n' + prefix).join(message.split('\n')))
AttributeError: 'exceptions.RuntimeError' object has no attribute 'split'
```

I wasn't sure if using `sys.exc_info()` was intentional, thought `RuntimeError as e` would be a bit more readable.

UPDATE: I found a misspelled variable which kind of related to this issue. Since it's a tiny pull request, I've included it as well.