### PR TITLE
Compute edit distance on word level

### DIFF
--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -766,7 +766,7 @@ def calculate_report(results_tuple):
         sample_wer = wer(label, decoding)
         sample = Sample(label, decoding, loss, distance, sample_wer)
         samples.append(sample)
-        total_levenshtein += levenshtein(label, decoding)
+        total_levenshtein += levenshtein(label.split(), decoding.split())
         total_label_length += float(len(label.split()))
 
     # Getting the WER from the accumulated levenshteins and lengths


### PR DESCRIPTION
This should fix the regression from 18b4120f302131a6653b589696db507382f0b050.

@kdavis-mozilla can you test this with the checkpoint to see if the results make more sense? Thanks.