### PR TITLE
Enable SWIG threads support in model.i

### DIFF
--- a/native_client/python/model.i
+++ b/native_client/python/model.i
@@ -1,4 +1,4 @@
-%module model
+%module(threads="1") model
 
 %{
 #define SWIG_FILE_WITH_INIT


### PR DESCRIPTION
Without this, `model.stt` will hold the GIL and block Python code in other threads.