### PR TITLE
Move decoder module initialization to initialize_globals

### DIFF
--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -325,6 +325,14 @@ def initialize_globals():
             log_error('Path specified in --one_shot_infer is not a valid file.')
             exit(1)
 
+    if not os.path.exists(os.path.abspath(FLAGS.decoder_library_path)):
+        print('ERROR: The decoder library file does not exist. Make sure you have ' \
+              'downloaded or built the native client binaries and pass the ' \
+              'appropriate path to the binaries in the --decoder_library_path parameter.')
+
+    global custom_op_module
+    custom_op_module = tf.load_op_library(FLAGS.decoder_library_path)
+
 
 # Logging functions
 # =================
@@ -477,13 +485,6 @@ def BiRNN(batch_x, seq_length, dropout):
 
     # Output shape: [n_steps, batch_size, n_hidden_6]
     return layer_6
-
-if not os.path.exists(os.path.abspath(FLAGS.decoder_library_path)):
-    print('ERROR: The decoder library file does not exist. Make sure you have ' \
-          'downloaded or built the native client binaries and pass the ' \
-          'appropriate path to the binaries in the --decoder_library_path parameter.')
-
-custom_op_module = tf.load_op_library(FLAGS.decoder_library_path)
 
 def decode_with_lm(inputs, sequence_length, beam_width=100,
                    top_paths=1, merge_repeated=True):


### PR DESCRIPTION
As of TF 1.5, you can't access tf.app.flags before `tf.app.run` is called.