### PR TITLE
Add a link to the gst-deepspeech GStreamer plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ In addition to the bindings above, third party developers have started to provid
 * [Asticode](https://github.com/asticode) provides [Golang](https://golang.org) bindings in its [go-astideepspeech](https://github.com/asticode/go-astideepspeech) repo.
 * [RustAudio](https://github.com/RustAudio) provide a [Rust](https://www.rust-lang.org) binding, the installation and use of which is described in their [deepspeech-rs](https://github.com/RustAudio/deepspeech-rs) repo.
 * [stes](https://github.com/stes) provides preliminary [PKGBUILDs](https://wiki.archlinux.org/index.php/PKGBUILD) to install the client and python bindings on [Arch Linux](https://www.archlinux.org/) in the [arch-deepspeech](https://github.com/stes/arch-deepspeech) repo.
+* [gst-deepspeech](https://github.com/Elleo/gst-deepspeech) provides a [GStreamer](https://gstreamer.freedesktop.org/) plugin which can be used from any language with GStreamer bindings.
 
 ## Training
 


### PR DESCRIPTION
This adds a link in the README to the gst-deepspeech project which provides a GStreamer element that wraps DeepSpeech and performs basic audio segmentation, making it usable for continuous dictation within a multimedia pipeline.