### PR TITLE
Fixed missing "requests" package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ python_speech_features
 pyxdg
 bs4
 six
+requests


### PR DESCRIPTION
When attempting to do local model training I noticed I had to manually install the "requests" package.  This should address that issue.