### PR TITLE
Remove keyword argument that has default value

### DIFF
--- a/bin/benchmark_nc.py
+++ b/bin/benchmark_nc.py
@@ -441,7 +441,7 @@ def produce_csv(input, output):
 
 def handle_args():
     parser = argparse.ArgumentParser(description='Benchmarking tooling for DeepSpeech native_client.')
-    parser.add_argument('--target', type=str, required=False,
+    parser.add_argument('--target', required=False,
                                  help='SSH user:pass@host string for remote benchmarking. This can also be a name of a matching \'Host\' in your SSH config.')
     parser.add_argument('--autotrust', action='store_true', default=False,
                                  help='SSH Paramiko policy to automatically trust unknown keys.')
@@ -453,19 +453,19 @@ def handle_args():
                                  help='Allow to look for SSH keys in ~/.ssh/.')
     parser.add_argument('--no-lookforkeys', action='store_false', dest='lookforkeys',
                                  help='Disallow to look for SSH keys in ~/.ssh/.')
-    parser.add_argument('--dir', type=str, required=False, default=None,
+    parser.add_argument('--dir', required=False, default=None,
                                  help='Local directory where to copy stuff. This will be mirrored to the remote system if needed (make sure to use path that will work on both).')
-    parser.add_argument('--models', type=str, nargs='+', required=False,
+    parser.add_argument('--models', nargs='+', required=False,
                                  help='List of files (protocolbuffer) to work on. Might be a zip file.')
-    parser.add_argument('--so-model', type=str, required=False,
+    parser.add_argument('--so-model', required=False,
                                  help='Perform one step using AOT-based .so model')
-    parser.add_argument('--wav', type=str, required=False,
+    parser.add_argument('--wav', required=False,
                                  help='WAV file to pass to native_client. Supply again in plotting mode to draw realine line.')
-    parser.add_argument('--alphabet', type=str, required=False,
+    parser.add_argument('--alphabet', required=False,
                                  help='Text file to pass to native_client for the alphabet.')
-    parser.add_argument('--lm_binary', type=str, required=False,
+    parser.add_argument('--lm_binary', required=False,
                                  help='Path to the LM binary file used by the decoder.')
-    parser.add_argument('--trie', type=str, required=False,
+    parser.add_argument('--trie', required=False,
                                  help='Path to the trie file used by the decoder.')
     parser.add_argument('--iters', type=int, required=False, default=5,
                                  help='How many iterations to perfom on each model.')
@@ -473,7 +473,7 @@ def handle_args():
                                  help='Keeping run files (binaries & models).')
     parser.add_argument('--csv', type=argparse.FileType('w'), required=False,
                                  help='Target CSV file where to dump data.')
-    parser.add_argument('--binaries', type=str, required=False, default=None,
+    parser.add_argument('--binaries', required=False, default=None,
                                  help='Specify non TaskCluster native_client.tar.xz to use')
     return parser.parse_args()
 

--- a/bin/benchmark_plotter.py
+++ b/bin/benchmark_plotter.py
@@ -117,19 +117,18 @@ def produce_plot_multiseries(input=None, output=None, title=None, size=None, fig
 
 def handle_args():
     parser = argparse.ArgumentParser(description='Benchmarking tooling for DeepSpeech native_client.')
-    parser.add_argument('--wav', type=str, required=False,
+    parser.add_argument('--wav', required=False,
                                  help='WAV file to pass to native_client. Supply again in plotting mode to draw realine line.')
     parser.add_argument('--dataset', action='append', nargs=2, metavar=('name','source'),
                                 help='Include dataset NAME from file SOURCE. Repeat the option to add more datasets.')
-    parser.add_argument('--title', type=str, default=None,
-                                help='Title of the plot.')
+    parser.add_argument('--title', default=None, help='Title of the plot.')
     parser.add_argument('--plot', type=argparse.FileType('w'), required=False,
                                 help='Target file where to plot data. Format will be deduced from extension.')
-    parser.add_argument('--size', type=str, default='800x600',
+    parser.add_argument('--size', default='800x600',
                                 help='Size (px) of the resulting plot.')
     parser.add_argument('--dpi', type=int, default=96,
                                 help='Set plot DPI.')
-    parser.add_argument('--range', type=str, default=None,
+    parser.add_argument('--range', default=None,
                                 help='Range of model size to use. Comma-separated string of boundaries: min,max')
     return parser.parse_args()
 

--- a/native_client/python/client.py
+++ b/native_client/python/client.py
@@ -54,15 +54,15 @@ def convert_samplerate(audio_path):
 
 def main():
     parser = argparse.ArgumentParser(description='Benchmarking tooling for DeepSpeech native_client.')
-    parser.add_argument('model', type=str,
+    parser.add_argument('model',
                         help='Path to the model (protocol buffer binary file)')
-    parser.add_argument('alphabet', type=str,
+    parser.add_argument('alphabet',
                         help='Path to the configuration file specifying the alphabet used by the network')
-    parser.add_argument('lm', type=str, nargs='?',
+    parser.add_argument('lm', nargs='?',
                         help='Path to the language model binary file')
-    parser.add_argument('trie', type=str, nargs='?',
+    parser.add_argument('trie', nargs='?',
                         help='Path to the language model trie file created with native_client/generate_trie')
-    parser.add_argument('audio', type=str,
+    parser.add_argument('audio',
                         help='Path to the audio file to run (WAV format)')
     args = parser.parse_args()
 

--- a/util/taskcluster.py
+++ b/util/taskcluster.py
@@ -61,16 +61,14 @@ if __name__ == '__main__':
     import argparse
 
     parser = argparse.ArgumentParser(description='Tooling to ease downloading of components from TaskCluster.')
-    parser.add_argument('--target', type=str, required=True,
+    parser.add_argument('--target', required=True,
                         help='Where to put the native client binary files')
-    parser.add_argument('--arch', type=str, required=False,
-                        default='cpu',
+    parser.add_argument('--arch', required=False, default='cpu',
                         help='Which architecture to download binaries for. "arm" for ARM 7 (32-bit), "gpu" for CUDA enabled x86_64 binaries, "cpu" for CPU-only x86_64 binaries, "osx" for CPU-only x86_64 OSX binaries. Optional ("cpu" by default)')
-    parser.add_argument('--artifact', type=str, required=False,
+    parser.add_argument('--artifact', required=False,
                         default='native_client.tar.xz',
                         help='Name of the artifact to download. Defaults to "native_client.tar.xz"')
-    parser.add_argument('--source', type=str, required=False,
-                        default=None,
+    parser.add_argument('--source', required=False, default=None,
                         help='Name of the TaskCluster scheme to use.')
 
     args = parser.parse_args()


### PR DESCRIPTION
When no `type` keyword argument is passed to the `add_argument` method of an `argparse.ArgumentParser`, the type will be `str` by default and therefore this does not need to be specified.