### PR TITLE
prefix_print utf message

### DIFF
--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -338,7 +338,7 @@ def initialize_globals():
 # =================
 
 def prefix_print(prefix, message):
-    print(prefix + ('\n' + prefix).join(message.split('\n')))
+    print(prefix + message.encode('utf-8').replace('\n', '\n'+prefix))
 
 def log_debug(message):
     if FLAGS.log_level == 0:


### PR DESCRIPTION
Hello.

I'm working on russian transcription. While running validation I get:
```python
Traceback (most recent call last):
  File "DeepSpeech.py", line 1660, in train
    log_debug('Sending %s...' % job)
  File "DeepSpeech.py", line 1432, in next_job
    self._epochs_done.append(epoch)
  File "DeepSpeech.py", line 353, in log_info
    if FLAGS.log_level <= 1:
  File "DeepSpeech.py", line 341, in prefix_print
    print(prefix + ('\n' + prefix).join(message.split('\n')))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 245-247: ordinal not in range(128)
```

So I add utf8 encode to prefix_print message. I think this shouldn't break anything. So give it a try.
