### PR TITLE
Explicit mention of supported platforms; should infer no default Wind…

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ See the output of `deepspeech -h` for more information on the use of `deepspeech
 
 * [Python 3.6](https://www.python.org/)
 * [Git Large File Storage](https://git-lfs.github.com/)
+* Mac or Linux environment
 
 ## Getting the code
 


### PR DESCRIPTION
Explicit mention of supported platforms; should infer no default Windows support

Currently there's no conspicuous list of supported platforms. This should make it clear from the pre-requisites which platforms are supported.

I wasted a fair bit of time when not realizing Windows was not supported. Having this would have helped.