### PR TITLE
Fix errors with uninitialized update_progressbar() field

### DIFF
--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -1646,6 +1646,9 @@ def train(server=None):
 
         update_progressbar.current_job_index += 1
 
+    # Initialize update_progressbar()'s child fields to safe values
+    update_progressbar.pbar = None
+
     # The MonitoredTrainingSession takes care of session initialization,
     # restoring from a checkpoint, saving to a checkpoint, and closing when done
     # or an error occurs.


### PR DESCRIPTION
There are multiple paths that could lead to trying to read `update_progressbar.pbar` without ever calling `update_progressbar()`, but they already check for `None`.