### PR TITLE
 Fixing broken link to 0.3.0 pre-trained models 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ git clone https://github.com/mozilla/DeepSpeech
 If you want to use the pre-trained English model for performing speech-to-text, you can download it (along with other important inference material) from the [DeepSpeech releases page](https://github.com/mozilla/DeepSpeech/releases). Alternatively, you can run the following command to download and unzip the files in your current directory:
 
 ```bash
-wget -O - https://github.com/mozilla/DeepSpeech/releases/download/v0.3.0/deepspeech-0.3.0-models.tar.gz | tar xvfz -
+wget -O - https://github.com/mozilla/DeepSpeech/releases/download/v0.2.0/deepspeech-0.2.0-models.tar.gz | tar xvfz -
 ```
 
 ## Using the model


### PR DESCRIPTION
The pre-trained models for 0.3.0 haven't been released yet, so people doing the quickstart encounter 404.
This change reverts the link back to 0.2.0 for now.