### PR TITLE
use TrainingSpeech release 2018-11-24_fr_FR

### DIFF
--- a/bin/import_ts.py
+++ b/bin/import_ts.py
@@ -22,7 +22,7 @@ from util.text import validate_label
 
 FIELDNAMES = ['wav_filename', 'wav_filesize', 'transcript']
 MAX_SECS = 10
-ARCHIVE_NAME = '2018-10-03_fr_FR'
+ARCHIVE_NAME = '2018-11-24_fr_FR'
 ARCHIVE_DIR_NAME = 'ts_' + ARCHIVE_NAME
 ARCHIVE_URL = 'https://s3.eu-west-3.amazonaws.com/audiocorp/releases/' + ARCHIVE_NAME + '.zip'
 


### PR DESCRIPTION
`2018-11-24_fr_FR` fixes many annotation issues (~500) such as empty audio etc.

@lissyx could you please take a look ?