### PR TITLE
Fix invalid characters in speech to text result

### DIFF
--- a/examples/net_framework/CSharpExamples/DeepSpeechClient/DeepSpeech.cs
+++ b/examples/net_framework/CSharpExamples/DeepSpeechClient/DeepSpeech.cs
@@ -2,6 +2,8 @@
 using DeepSpeechClient.Structs;
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace DeepSpeechClient
 {
@@ -182,7 +184,14 @@ namespace DeepSpeechClient
         /// <returns>The STT result. The user is responsible for freeing the string.  Returns NULL on error.</returns>
         public unsafe string SpeechToText(short[] aBuffer, uint aBufferSize, uint aSampleRate)
         {
-            return NativeImp.DS_SpeechToText(_modelStatePP, aBuffer, aBufferSize, aSampleRate);
+            var res = NativeImp.DS_SpeechToText(_modelStatePP, aBuffer, aBufferSize, aSampleRate);
+
+            int len = 0;
+            while (Marshal.ReadByte(res, len) != 0) ++len;
+            byte[] buffer = new byte[len];
+            Marshal.Copy(res, buffer, 0, buffer.Length);
+            return Encoding.UTF8.GetString(buffer);
+            //return NativeImp.DS_SpeechToText(_modelStatePP, aBuffer, aBufferSize, aSampleRate);
         }
 
         #endregion

--- a/examples/net_framework/CSharpExamples/DeepSpeechClient/NativeImp.cs
+++ b/examples/net_framework/CSharpExamples/DeepSpeechClient/NativeImp.cs
@@ -1,4 +1,5 @@
-﻿using DeepSpeechClient.Structs;
+﻿using System;
+using DeepSpeechClient.Structs;
 using System.Runtime.InteropServices;
 
 namespace DeepSpeechClient
@@ -30,7 +31,7 @@ namespace DeepSpeechClient
 
         [DllImport("libdeepspeech.so", CallingConvention = CallingConvention.Cdecl,
             CharSet = CharSet.Ansi, SetLastError = true)]
-        internal static unsafe extern string DS_SpeechToText(ModelState** aCtx,
+        internal static unsafe extern IntPtr DS_SpeechToText(ModelState** aCtx,
                  short[] aBuffer,
                 uint aBufferSize,
                 uint aSampleRate);


### PR DESCRIPTION
Default string in .NET uses UTF-16 causing invalid characters to appear as mentioned in [here](https://discourse.mozilla.org/t/multilingual-dataset-combiner-cleaner/34788/13?u=roseman). This pull fixes the issue by returning the result as UTF-8.