### PR TITLE
Removed link to ReadTheDocs docs as they were not well maintained.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Project DeepSpeech
 
-[![Documentation Status](https://readthedocs.org/projects/deepspeech/badge/?version=latest)](http://deepspeech.readthedocs.io/?badge=latest)
 [![Task Status](https://github.taskcluster.net/v1/repository/mozilla/DeepSpeech/master/badge.svg)](https://github.taskcluster.net/v1/repository/mozilla/DeepSpeech/master/latest)
 
 Project DeepSpeech is an open source Speech-To-Text engine, using a model trained by machine learning techniques, based on [Baidu's Deep Speech research paper](https://arxiv.org/abs/1412.5567). Project DeepSpeech uses Google's [TensorFlow](https://www.tensorflow.org/) project to make the implementation easier.


### PR DESCRIPTION
Fixed #1861 by removing the link and the associated  GitHub Service.