### PR TITLE
allow custom export_batch_size (see #1920)

### DIFF
--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -749,7 +749,7 @@ def export():
         tf.reset_default_graph()
         session = tf.Session(config=Config.session_config)
 
-        inputs, outputs, _ = create_inference_graph(batch_size=1, n_steps=FLAGS.n_steps, tflite=FLAGS.export_tflite)
+        inputs, outputs, _ = create_inference_graph(batch_size=FLAGS.export_batch_size, n_steps=FLAGS.n_steps, tflite=FLAGS.export_tflite)
         input_names = ",".join(tensor.op.name for tensor in inputs.values())
         output_names_tensors = [ tensor.op.name for tensor in outputs.values() if isinstance(tensor, Tensor) ]
         output_names_ops = [ tensor.name for tensor in outputs.values() if isinstance(tensor, Operation) ]


### PR DESCRIPTION
NB: for now `export_batch_size` must be greater than or equal to 1 due to https://github.com/mozilla/DeepSpeech/blame/master/DeepSpeech.py#L672 and https://github.com/mozilla/DeepSpeech/blame/master/DeepSpeech.py#L703

It would be nice to enable dynamic `batch_size` but outside the scope of this PR

BTW, 
flag `export_batch_size` was already there but was not used. see https://github.com/mozilla/DeepSpeech/blame/master/util/flags.py#L65