### PR TITLE
skip file header of CSV file when reading alphabet

### DIFF
--- a/util/check_characters.py
+++ b/util/check_characters.py
@@ -37,6 +37,7 @@ for inFile in (inFiles):
     with open(inFile, "r") as csvFile:
         reader = csv.reader(csvFile)
         try:
+            next(reader, None)  # skip the file header (i.e. "transcript")
             for row in reader:
                 allText |= set(str(row[2]))
         except IndexError as ie:


### PR DESCRIPTION
When reading in a CSV, this script (in error) has been reading in the characters from the header.

For English and most Roman alphabet languages, this isn't noticed, but for non-Roman alphabets we end up adding the unique letters of the column header `transcript` into the alphabet.

This small fix just skips over the header.