### PR TITLE
Make bin/run-ldc93s1.sh run faster

### DIFF
--- a/bin/run-ldc93s1.sh
+++ b/bin/run-ldc93s1.sh
@@ -23,7 +23,7 @@ python -u DeepSpeech.py \
   --train_batch_size 1 \
   --dev_batch_size 1 \
   --test_batch_size 1 \
-  --n_hidden 494 \
-  --epoch 75 \
+  --n_hidden 100 \
+  --epoch 200 \
   --checkpoint_dir "$checkpoint_dir" \
   "$@"


### PR DESCRIPTION
The main use of bin/run-ldc93s1.sh is to test our code, not any training aspect, so I propose we make it faster to speed-up edit-test cycles. With these changes I can run it in 5 seconds on my laptop CPU, which is pretty good.