### PR TITLE
Output word timings

### DIFF
--- a/native_client/args.h
+++ b/native_client/args.h
@@ -26,10 +26,12 @@ bool show_times = false;
 
 bool has_versions = false;
 
+bool extended_metadata = false;
+
 void PrintHelp(const char* bin)
 {
     std::cout <<
-    "Usage: " << bin << " --model MODEL --alphabet ALPHABET [--lm LM --trie TRIE] --audio AUDIO [-t]\n"
+    "Usage: " << bin << " --model MODEL --alphabet ALPHABET [--lm LM --trie TRIE] --audio AUDIO [-t] [-e]\n"
     "\n"
     "Running DeepSpeech inference.\n"
     "\n"
@@ -39,6 +41,7 @@ void PrintHelp(const char* bin)
     "	--trie TRIE		Path to the language model trie file created with native_client/generate_trie\n"
     "	--audio AUDIO		Path to the audio file to run (WAV format)\n"
     "	-t			Run in benchmark mode, output mfcc & inference time\n"
+    "	-e			Extended output, shows word timings as CSV (word, start time, duration)\n"
     "	--help			Show help\n"
     "	--version		Print version and exits\n";
     DS_PrintVersions();
@@ -47,7 +50,7 @@ void PrintHelp(const char* bin)
 
 bool ProcessArgs(int argc, char** argv)
 {
-    const char* const short_opts = "m:a:l:r:w:thv";
+    const char* const short_opts = "m:a:l:r:w:tehv";
     const option long_opts[] = {
             {"model", required_argument, nullptr, 'm'},
             {"alphabet", required_argument, nullptr, 'a'},
@@ -56,6 +59,7 @@ bool ProcessArgs(int argc, char** argv)
             {"audio", required_argument, nullptr, 'w'},
             {"run_very_slowly_without_trie_I_really_know_what_Im_doing", no_argument, nullptr, 999},
             {"t", no_argument, nullptr, 't'},
+            {"e", no_argument, nullptr, 'e'},
             {"help", no_argument, nullptr, 'h'},
             {"version", no_argument, nullptr, 'v'},
             {nullptr, no_argument, nullptr, 0}
@@ -100,6 +104,10 @@ bool ProcessArgs(int argc, char** argv)
 
         case 'v':
             has_versions = true;
+            break;
+
+        case 'e':
+            extended_metadata = true;
             break;
 
         case 'h': // -h or --help

--- a/native_client/client.cc
+++ b/native_client/client.cc
@@ -28,6 +28,7 @@
 #include <dirent.h>
 #include <unistd.h>
 #endif // NO_DIR
+#include <vector>
 
 #include "deepspeech.h"
 #include "args.h"
@@ -43,15 +44,30 @@ typedef struct {
   double cpu_time_overall;
 } ds_result;
 
+struct meta_word {
+  std::string word;
+  float start_time;
+  float duration;
+};
+
+std::vector<meta_word> WordsFromMetadata(Metadata* metadata);
+char* CSVOutput(std::vector<meta_word> words);
+
 ds_result
 LocalDsSTT(ModelState* aCtx, const short* aBuffer, size_t aBufferSize,
-           int aSampleRate)
+           int aSampleRate, bool extended_output)
 {
   ds_result res = {0};
 
   clock_t ds_start_time = clock();
 
-  res.string = DS_SpeechToText(aCtx, aBuffer, aBufferSize, aSampleRate);
+  if (extended_output) {
+    Metadata *metadata = DS_SpeechToTextWithMetadata(aCtx, aBuffer, aBufferSize, aSampleRate);
+    res.string = CSVOutput(WordsFromMetadata(metadata));
+    DS_FreeMetadata(metadata);
+  } else {
+    res.string = DS_SpeechToText(aCtx, aBuffer, aBufferSize, aSampleRate);
+  }  
 
   clock_t ds_end_infer = clock();
 
@@ -224,7 +240,8 @@ ProcessFile(ModelState* context, const char* path, bool show_times)
   ds_result result = LocalDsSTT(context,
                                 (const short*)audio.buffer,
                                 audio.buffer_size / 2,
-                                audio.sample_rate);
+                                audio.sample_rate,
+                                extended_metadata);
   free(audio.buffer);
 
   if (result.string) {
@@ -236,6 +253,66 @@ ProcessFile(ModelState* context, const char* path, bool show_times)
     printf("cpu_time_overall=%.05f\n",
            result.cpu_time_overall);
   }
+}
+
+std::vector<meta_word>
+WordsFromMetadata(Metadata* metadata)
+{
+  std::vector<meta_word> word_list;
+
+  std::string word = "";
+  float word_start_time = 0;
+
+  // Loop through each character
+  for (int i = 0; i < metadata->num_items; i++) {
+    MetadataItem item = metadata->items[i];
+
+    if (strcmp(item.character, " ") != 0) {
+      word.append(item.character);
+    }
+
+    // Word boundary is either a space or the last character in the array
+    if (strcmp(item.character, " ") == 0 || 
+        i == metadata->num_items-1) {
+        
+      float word_duration = item.start_time - word_start_time;
+      
+      if (word_duration < 0) {
+        word_duration = 0;
+      }
+      
+      meta_word w;
+      w.word = word;
+      w.start_time = word_start_time;
+      w.duration = word_duration;
+
+      word_list.push_back(w);
+
+      // Reset
+      word = "";
+      word_start_time = 0;
+
+    } else {
+      if (word.length() == 1) {
+        word_start_time = item.start_time; // Log the start time of the new word
+      }
+    }
+  }
+
+  return word_list;
+}
+
+char* 
+CSVOutput(std::vector<meta_word> words)
+{
+  std::ostringstream out_string;
+
+  for (int i = 0; i < words.size(); i++) {
+    meta_word w = words[i];  
+    out_string << w.word << "," << std::to_string(w.start_time) << "," << std::to_string(w.duration) << "\n";
+  }
+  
+  return strdup(out_string.str().c_str());
 }
 
 int

--- a/native_client/client.cc
+++ b/native_client/client.cc
@@ -267,12 +267,14 @@ WordsFromMetadata(Metadata* metadata)
   for (int i = 0; i < metadata->num_items; i++) {
     MetadataItem item = metadata->items[i];
 
-    if (strcmp(item.character, " ") != 0) {
+    // Append character to word if it's not a space
+    if (strcmp(item.character, " ") != 0 || strcmp(item.character, u8"　") != 0) {
       word.append(item.character);
     }
 
     // Word boundary is either a space or the last character in the array
     if (strcmp(item.character, " ") == 0 
+        || strcmp(item.character, u8" ") == 0 
         || i == metadata->num_items-1) {
         
       float word_duration = item.start_time - word_start_time;

--- a/native_client/client.cc
+++ b/native_client/client.cc
@@ -268,7 +268,8 @@ WordsFromMetadata(Metadata* metadata)
     MetadataItem item = metadata->items[i];
 
     // Append character to word if it's not a space
-    if (strcmp(item.character, " ") != 0 || strcmp(item.character, u8"　") != 0) {
+    if (strcmp(item.character, " ") != 0 
+        || strcmp(item.character, u8"　") != 0) {
       word.append(item.character);
     }
 

--- a/native_client/deepspeech.cc
+++ b/native_client/deepspeech.cc
@@ -491,15 +491,10 @@ Metadata* ModelState::decode_metadata(vector<float>& logits)
 
   // Loop through each character
   for (int i = 0; i < out[0].tokens.size(); ++i) {
-    char* character = (char*)alphabet->StringFromLabel(out[0].tokens[i]).c_str();
-
-    // Note: 1 timestep = 20ms
-    float start_time = static_cast<float>(out[0].timesteps[i] * AUDIO_WIN_STEP);
-
     MetadataItem item;
-    item.character = character; 
+    item.character = (char*)alphabet->StringFromLabel(out[0].tokens[i]).c_str(); 
     item.timestep = out[0].timesteps[i]; 
-    item.start_time = start_time;
+    item.start_time = static_cast<float>(out[0].timesteps[i] * AUDIO_WIN_STEP);
     
     if (item.start_time < 0) {
       item.start_time = 0;

--- a/native_client/deepspeech.cc
+++ b/native_client/deepspeech.cc
@@ -485,22 +485,23 @@ Metadata* ModelState::decode_metadata(vector<float>& logits)
 {
   vector<Output> out = decode_raw(logits);
 
-  Metadata* metadata = (Metadata*)malloc(sizeof (Metadata));
+  Metadata* metadata = new Metadata;
   metadata->num_items = out[0].tokens.size();
-  metadata->items = (MetadataItem*)malloc(sizeof(MetadataItem) * metadata->num_items);
+  metadata->items = new MetadataItem[metadata->num_items];
 
   // Loop through each character
   for (int i = 0; i < out[0].tokens.size(); ++i) {
-    MetadataItem item;
-    item.character = (char*)alphabet->StringFromLabel(out[0].tokens[i]).c_str(); 
-    item.timestep = out[0].timesteps[i]; 
-    item.start_time = static_cast<float>(out[0].timesteps[i] * AUDIO_WIN_STEP);
+    MetadataItem *item = new MetadataItem;
+    item->character = (char*)alphabet->StringFromLabel(out[0].tokens[i]).c_str(); 
+    item->timestep = out[0].timesteps[i]; 
+    item->start_time = static_cast<float>(out[0].timesteps[i] * AUDIO_WIN_STEP);
     
-    if (item.start_time < 0) {
-      item.start_time = 0;
+    if (item->start_time < 0) {
+      item->start_time = 0;
     }
     
-    metadata->items[i] = item;
+    metadata->items[i] = *item;
+    delete(item);
   }
 
   return metadata;
@@ -916,8 +917,8 @@ DS_AudioToInputVector(const short* aBuffer,
 void 
 DS_FreeMetadata(Metadata* m) 
 {  
-  free(m->items);
-  free(m);
+  delete(m->items);
+  delete(m);
 }
 
 void

--- a/native_client/deepspeech.cc
+++ b/native_client/deepspeech.cc
@@ -914,8 +914,10 @@ DS_AudioToInputVector(const short* aBuffer,
 void 
 DS_FreeMetadata(Metadata* m) 
 {  
-  delete(m->items);
-  delete(m);
+  if (m) {
+    delete(m->items);
+    delete(m);
+  }
 }
 
 void

--- a/native_client/deepspeech.cc
+++ b/native_client/deepspeech.cc
@@ -115,7 +115,9 @@ struct StreamingState {
 
   void feedAudioContent(const short* buffer, unsigned int buffer_size);
   char* intermediateDecode();
+  void finalizeStream();
   char* finishStream();
+  Metadata* finishStreamWithMetadata();
 
   void processAudioWindow(const vector<float>& buf);
   void processMfccWindow(const vector<float>& buf);
@@ -171,6 +173,28 @@ struct ModelState {
   char* decode(vector<float>& logits);
 
   /**
+   * @brief Perform decoding of the logits, using basic CTC decoder or
+   *        CTC decoder with KenLM enabled
+   *
+   * @param logits         Flat matrix of logits, of size:
+   *                       n_frames * batch_size * num_classes
+   *
+   * @return Vector of Output structs directly from the CTC decoder for additional processing.
+   */
+  vector<Output> decode_raw(vector<float>& logits);
+
+  /**
+   * @brief Return character-level metadata including letter timings.
+   *
+   * @param logits          Flat matrix of logits, of size:
+   *                        n_frames * batch_size * num_classes
+   *
+   * @return Metadata struct containing MetadataItem structs for each character.
+   * The user is responsible for freeing Metadata and Metadata.items.
+   */
+  Metadata* decode_metadata(vector<float>& logits); 
+
+  /**
    * @brief Do a single inference step in the acoustic model, with:
    *          input=mfcc
    *          input_lengths=[n_frames]
@@ -182,6 +206,9 @@ struct ModelState {
    */
   void infer(const float* mfcc, unsigned int n_frames, vector<float>& output_logits);
 };
+
+StreamingState* setupStreamAndFeedAudioContent(ModelState* aCtx, const short* aBuffer,
+                                               unsigned int aBufferSize, unsigned int aSampleRate);
 
 ModelState::ModelState()
   :
@@ -260,20 +287,17 @@ StreamingState::intermediateDecode()
 char*
 StreamingState::finishStream()
 {
-  // Flush audio buffer
-  processAudioWindow(audio_buffer);
-
-  // Add empty mfcc vectors at end of sample
-  for (int i = 0; i < model->n_context; ++i) {
-    addZeroMfccWindow();
-  }
-
-  // Process final batch
-  if (batch_buffer.size() > 0) {
-    processBatch(batch_buffer, batch_buffer.size()/model->mfcc_feats_per_timestep);
-  }
+  finalizeStream();
 
   return model->decode(accumulated_logits);
+}
+
+Metadata*
+StreamingState::finishStreamWithMetadata()
+{
+  finalizeStream();
+
+  return model->decode_metadata(accumulated_logits);
 }
 
 void
@@ -289,6 +313,23 @@ StreamingState::processAudioWindow(const vector<float>& buf)
 
   pushMfccBuffer(mfcc, n_frames * MFCC_FEATURES);
   free(mfcc);
+}
+
+void
+StreamingState::finalizeStream()
+{
+  // Flush audio buffer
+  processAudioWindow(audio_buffer);
+
+  // Add empty mfcc vectors at end of sample
+  for (int i = 0; i < model->n_context; ++i) {
+    addZeroMfccWindow();
+  }
+
+  // Process final batch
+  if (batch_buffer.size() > 0) {
+    processBatch(batch_buffer, batch_buffer.size()/model->mfcc_feats_per_timestep);
+  }
 }
 
 void
@@ -416,6 +457,14 @@ ModelState::infer(const float* aMfcc, unsigned int n_frames, vector<float>& logi
 char*
 ModelState::decode(vector<float>& logits)
 {
+  vector<Output> out = ModelState::decode_raw(logits);
+
+  return strdup(alphabet->LabelsToString(out[0].tokens).c_str());
+}
+
+vector<Output>
+ModelState::decode_raw(vector<float>& logits)
+{
   const int cutoff_top_n = 40;
   const double cutoff_prob = 1.0;
   const size_t num_classes = alphabet->GetSize() + 1; // +1 for blank
@@ -429,7 +478,37 @@ ModelState::decode(vector<float>& logits)
     inputs.data(), n_frames, num_classes, *alphabet, beam_width,
     cutoff_prob, cutoff_top_n, scorer);
 
-  return strdup(alphabet->LabelsToString(out[0].tokens).c_str());
+  return out;
+}
+
+Metadata* ModelState::decode_metadata(vector<float>& logits) 
+{
+  vector<Output> out = decode_raw(logits);
+
+  Metadata* metadata = (Metadata*)malloc(sizeof (Metadata));
+  metadata->num_items = out[0].tokens.size();
+  metadata->items = (MetadataItem*)malloc(sizeof(MetadataItem) * metadata->num_items);
+
+  // Loop through each character
+  for (int i = 0; i < out[0].tokens.size(); ++i) {
+    char* character = (char*)alphabet->StringFromLabel(out[0].tokens[i]).c_str();
+
+    // Note: 1 timestep = 20ms
+    float start_time = static_cast<float>(out[0].timesteps[i] * AUDIO_WIN_STEP);
+
+    MetadataItem item;
+    item.character = character; 
+    item.timestep = out[0].timesteps[i]; 
+    item.start_time = start_time;
+    
+    if (item.start_time < 0) {
+      item.start_time = 0;
+    }
+    
+    metadata->items[i] = item;
+  }
+
+  return metadata;
 }
 
 #ifdef USE_TFLITE
@@ -661,13 +740,35 @@ DS_SpeechToText(ModelState* aCtx,
                 unsigned int aBufferSize,
                 unsigned int aSampleRate)
 {
+  StreamingState* ctx = setupStreamAndFeedAudioContent(aCtx, aBuffer, aBufferSize, aSampleRate);
+  return DS_FinishStream(ctx);
+}
+
+Metadata*
+DS_SpeechToTextWithMetadata(ModelState* aCtx,
+                            const short* aBuffer,
+                            unsigned int aBufferSize,
+                            unsigned int aSampleRate)
+{
+  StreamingState* ctx = setupStreamAndFeedAudioContent(aCtx, aBuffer, aBufferSize, aSampleRate);
+  return DS_FinishStreamWithMetadata(ctx);
+}
+
+StreamingState* 
+setupStreamAndFeedAudioContent(ModelState* aCtx,
+                                  const short* aBuffer,
+                                  unsigned int aBufferSize,
+                                  unsigned int aSampleRate)
+{
   StreamingState* ctx;
   int status = DS_SetupStream(aCtx, 0, aSampleRate, &ctx);
   if (status != DS_ERR_OK) {
     return nullptr;
   }
+      
   DS_FeedAudioContent(ctx, aBuffer, aBufferSize);
-  return DS_FinishStream(ctx);
+
+  return ctx;
 }
 
 int
@@ -733,6 +834,14 @@ DS_FinishStream(StreamingState* aSctx)
   char* str = aSctx->finishStream();
   DS_DiscardStream(aSctx);
   return str;
+}
+
+Metadata*
+DS_FinishStreamWithMetadata(StreamingState* aSctx)
+{
+  Metadata* metadata = aSctx->finishStreamWithMetadata();
+  DS_DiscardStream(aSctx);
+  return metadata;
 }
 
 void
@@ -807,6 +916,13 @@ DS_AudioToInputVector(const short* aBuffer,
   if (aFrameLen) {
     *aFrameLen = frameSize;
   }
+}
+
+void 
+DS_FreeMetadata(Metadata* m) 
+{  
+  free(m->items);
+  free(m);
 }
 
 void

--- a/native_client/deepspeech.cc
+++ b/native_client/deepspeech.cc
@@ -181,7 +181,7 @@ struct ModelState {
    *
    * @return Vector of Output structs directly from the CTC decoder for additional processing.
    */
-  vector<Output> decode_raw(vector<float>& logits);
+  vector<Output> decode_raw(const vector<float>& logits);
 
   /**
    * @brief Return character-level metadata including letter timings.
@@ -190,7 +190,7 @@ struct ModelState {
    *                        n_frames * batch_size * num_classes
    *
    * @return Metadata struct containing MetadataItem structs for each character.
-   * The user is responsible for freeing Metadata and Metadata.items.
+   * The user is responsible for freeing Metadata by calling DS_FreeMetadata().
    */
   Metadata* decode_metadata(vector<float>& logits); 
 
@@ -463,7 +463,7 @@ ModelState::decode(vector<float>& logits)
 }
 
 vector<Output>
-ModelState::decode_raw(vector<float>& logits)
+ModelState::decode_raw(const vector<float>& logits)
 {
   const int cutoff_top_n = 40;
   const double cutoff_prob = 1.0;

--- a/native_client/deepspeech.h
+++ b/native_client/deepspeech.h
@@ -133,7 +133,7 @@ char* DS_SpeechToText(ModelState* aCtx,
  * @param aSampleRate The sample-rate of the audio signal.
  *
  * @return Outputs a struct of individual letters along with their timing information. 
- *         The user is responsible for freeing Metadata and Metadata.items. Returns NULL on error.
+ *         The user is responsible for freeing Metadata by calling {@link DS_FreeMetadata()}. Returns NULL on error.
  */
 DEEPSPEECH_EXPORT
 Metadata* DS_SpeechToTextWithMetadata(ModelState* aCtx,
@@ -209,7 +209,7 @@ char* DS_FinishStream(StreamingState* aSctx);
  * @param aSctx A streaming state pointer returned by {@link DS_SetupStream()}.
  *
  * @return Outputs a struct of individual letters along with their timing information. 
- *         The user is responsible for freeing Metadata and Metadata.items. Returns NULL on error.
+ *         The user is responsible for freeing Metadata by calling {@link DS_FreeMetadata()}. Returns NULL on error.
  *
  * @note This method will free the state pointer (@p aSctx).
  */

--- a/native_client/deepspeech.h
+++ b/native_client/deepspeech.h
@@ -15,6 +15,19 @@ struct ModelState;
 
 struct StreamingState;
 
+// Stores each individual character, along with its timing information
+struct MetadataItem {
+  char* character;
+  int timestep; // Position of the character in units of 20ms
+  float start_time; // Position of the character in seconds
+};
+
+// Stores the entire CTC output as an array of character metadata objects
+struct Metadata {
+  MetadataItem* items;
+  int num_items;
+};
+
 enum DeepSpeech_Error_Codes
 {
     // OK
@@ -110,6 +123,25 @@ char* DS_SpeechToText(ModelState* aCtx,
                       unsigned int aSampleRate);
 
 /**
+ * @brief Use the DeepSpeech model to perform Speech-To-Text and output metadata 
+ * about the results.
+ *
+ * @param aCtx The ModelState pointer for the model to use.
+ * @param aBuffer A 16-bit, mono raw audio signal at the appropriate
+ *                sample rate.
+ * @param aBufferSize The number of samples in the audio signal.
+ * @param aSampleRate The sample-rate of the audio signal.
+ *
+ * @return Outputs a struct of individual letters along with their timing information. 
+ *         The user is responsible for freeing Metadata and Metadata.items. Returns NULL on error.
+ */
+DEEPSPEECH_EXPORT
+Metadata* DS_SpeechToTextWithMetadata(ModelState* aCtx,
+                      const short* aBuffer,
+                      unsigned int aBufferSize,
+                      unsigned int aSampleRate);
+
+/**
  * @brief Create a new streaming inference state. The streaming state returned
  *        by this function can then be passed to {@link DS_FeedAudioContent()}
  *        and {@link DS_FinishStream()}.
@@ -171,6 +203,20 @@ DEEPSPEECH_EXPORT
 char* DS_FinishStream(StreamingState* aSctx);
 
 /**
+ * @brief Signal the end of an audio signal to an ongoing streaming
+ *        inference, returns per-letter metadata.
+ *
+ * @param aSctx A streaming state pointer returned by {@link DS_SetupStream()}.
+ *
+ * @return Outputs a struct of individual letters along with their timing information. 
+ *         The user is responsible for freeing Metadata and Metadata.items. Returns NULL on error.
+ *
+ * @note This method will free the state pointer (@p aSctx).
+ */
+DEEPSPEECH_EXPORT
+Metadata* DS_FinishStreamWithMetadata(StreamingState* aSctx);
+
+/**
  * @brief Destroy a streaming state without decoding the computed logits. This
  *        can be used if you no longer need the result of an ongoing streaming
  *        inference and don't want to perform a costly decode operation.
@@ -212,6 +258,13 @@ void DS_AudioToInputVector(const short* aBuffer,
                            float** aMfcc,
                            int* aNFrames = NULL,
                            int* aFrameLen = NULL);
+
+/**
+ * @brief Free memory allocated for metadata information.
+ */
+
+DEEPSPEECH_EXPORT
+void DS_FreeMetadata(Metadata* m); 
 
 /**
  * @brief Print version of this library and of the linked TensorFlow library.


### PR DESCRIPTION
Letter timings are exposed on the API and the client then converts these into word-level timings. The client outputs CSV when used with the -e command-line argument.