### PR TITLE
ignore_longer_outputs_than_inputs=True

### DIFF
--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -186,7 +186,7 @@ def calculate_mean_edit_distance_and_loss(model_feeder, tower, dropout, reuse):
     logits, _ = BiRNN(batch_x, batch_seq_len, dropout, reuse)
 
     # Compute the CTC loss using TensorFlow's `ctc_loss`
-    total_loss = tf.nn.ctc_loss(labels=batch_y, inputs=logits, sequence_length=batch_seq_len)
+    total_loss = tf.nn.ctc_loss(labels=batch_y, inputs=logits, sequence_length=batch_seq_len, ignore_longer_outputs_than_inputs=True)
 
     # Calculate the average loss across the batch
     avg_loss = tf.reduce_mean(total_loss)

--- a/evaluate.py
+++ b/evaluate.py
@@ -86,7 +86,8 @@ def evaluate(test_data, inference_graph):
 
         loss = tf.nn.ctc_loss(labels=sparse_labels,
                               inputs=layers['raw_logits'],
-                              sequence_length=inputs['input_lengths'])
+                              sequence_length=inputs['input_lengths'],
+                              ignore_longer_outputs_than_inputs=True)
 
         # Create a saver using variables from the above newly created graph
         mapping = {v.op.name: v for v in tf.global_variables() if not v.op.name.startswith('previous_state_')}


### PR DESCRIPTION
I vote for adding this in as a default, because otherwise it might be the case that you train on CV for 2 days with 8 GPUs and it crashes at test time