### PR TITLE
Update README for paramiko/cryptography dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ In addition to the bindings above, third party developers have started to provid
 Install the required dependencies using `pip3`:
 
 ```bash
+sudo apt-get install build-essential libssl-dev libffi-dev python-dev
 cd DeepSpeech
 pip3 install -r requirements.txt
 ```


### PR DESCRIPTION
On a pristine WSL Ubuntu image additional dependencies
were required. This ensures those dependencies get
installed with apt, thereby avoiding a hard to diagnose
stack trace.