### PR TITLE
Use std::map to fix compilation issue with clang

### DIFF
--- a/native_client/ctcdecode/third_party/openfst-1.6.7/src/include/fst/symbol-table.h
+++ b/native_client/ctcdecode/third_party/openfst-1.6.7/src/include/fst/symbol-table.h
@@ -196,7 +196,7 @@ class SymbolTableImpl {
   std::vector<int64> idx_key_;
   // Maps key to index for key >= dense_key_limit_.
   //  index = key_map_[key]
-  map<int64, int64> key_map_;
+  std::map<int64, int64> key_map_;
 
   mutable bool check_sum_finalized_;
   mutable string check_sum_string_;


### PR DESCRIPTION
When building with clang the following compilation error is thrown:

symbol-table.h:199:3: error: no template named 'map'
    map<int64, int64> key_map_;
    ^

This patch solves that issue by explicitly specifying the std namespace.