### PR TITLE
Perform separate validation and test epochs per dataset when multiple files are specified (Fixes #1634 and #2043)

### DIFF
--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -22,7 +22,7 @@ from tensorflow.python.tools import freeze_graph
 from util.config import Config, initialize_globals
 from util.feeding import create_dataset, samples_to_mfccs, audiofile_to_features
 from util.flags import create_flags, FLAGS
-from util.logging import log_info, log_error, log_debug
+from util.logging import log_info, log_error, log_debug, log_progress, create_progressbar
 
 
 # Graph Creation
@@ -425,15 +425,6 @@ def train():
 
     initializer = tf.global_variables_initializer()
 
-    # Disable progress logging if needed
-    if FLAGS.show_progressbar:
-        pbar_class = progressbar.ProgressBar
-        def log_progress(*args, **kwargs):
-            pass
-    else:
-        pbar_class = progressbar.NullBar
-        log_progress = log_info
-
     with tf.Session(config=Config.session_config) as session:
         log_debug('Session opened.')
 
@@ -479,7 +470,7 @@ def train():
                        ' | Steps: ', progressbar.widgets.Counter(),
                        ' | ', LossWidget()]
             suffix = ' | Dataset: {}'.format(dataset) if dataset else None
-            pbar = pbar_class(prefix=prefix, widgets=widgets, suffix=suffix, fd=sys.stdout).start()
+            pbar = create_progressbar(prefix=prefix, widgets=widgets, suffix=suffix).start()
 
             # Initialize iterator to the appropriate dataset
             session.run(init_op)

--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -367,7 +367,7 @@ def train():
     # Create training and validation datasets
     train_set = create_dataset(FLAGS.train_files.split(','),
                                batch_size=FLAGS.train_batch_size,
-                               cache_path=FLAGS.train_cached_features_path)
+                               cache_path=FLAGS.feature_cache)
 
     iterator = tf.data.Iterator.from_structure(train_set.output_types,
                                                train_set.output_shapes,

--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -14,6 +14,7 @@ import progressbar
 import shutil
 import tensorflow as tf
 
+from datetime import datetime
 from ds_ctcdecoder import ctc_beam_search_decoder, Scorer
 from evaluate import evaluate
 from six.moves import zip, range
@@ -508,6 +509,7 @@ def train():
             return mean_loss
 
         log_info('STARTING Optimization')
+        train_start_time = datetime.utcnow()
         best_dev_loss = float('inf')
         dev_losses = []
         try:
@@ -551,6 +553,7 @@ def train():
                             break
         except KeyboardInterrupt:
             pass
+        log_info('FINISHED optimization in {}'.format(datetime.utcnow() - train_start_time))
     log_debug('Session closed.')
 
 

--- a/bin/run-tc-ldc93s1_new.sh
+++ b/bin/run-tc-ldc93s1_new.sh
@@ -14,7 +14,7 @@ fi;
 
 python -u DeepSpeech.py --noshow_progressbar --noearly_stop \
   --train_files ${ldc93s1_csv} --train_batch_size 1 \
-  --train_cached_features_path '/tmp/ldc93s1_cache' \
+  --feature_cache '/tmp/ldc93s1_cache' \
   --dev_files ${ldc93s1_csv} --dev_batch_size 1 \
   --test_files ${ldc93s1_csv} --test_batch_size 1 \
   --n_hidden 100 --epochs $epoch_count \

--- a/evaluate.py
+++ b/evaluate.py
@@ -18,7 +18,7 @@ from util.config import Config, initialize_globals
 from util.evaluate_tools import calculate_report
 from util.feeding import create_dataset
 from util.flags import create_flags, FLAGS
-from util.logging import log_error
+from util.logging import log_error, log_progress, create_progressbar
 from util.text import levenshtein
 
 
@@ -93,9 +93,9 @@ def evaluate(test_csvs, create_model, try_loading):
             seq_lengths = []
             ground_truths = []
 
-            bar = progressbar.ProgressBar(prefix='Computing acoustic model predictions | ',
-                                          widgets=['Steps: ', progressbar.Counter(), ' | ', progressbar.Timer()],
-                                          fd=sys.stdout).start()
+            bar = create_progressbar(prefix='Computing acoustic model predictions | ',
+                                     widgets=['Steps: ', progressbar.Counter(), ' | ', progressbar.Timer()]).start()
+            log_progress('Computing acoustic model predictions...')
 
             step_count = 0
 
@@ -121,9 +121,9 @@ def evaluate(test_csvs, create_model, try_loading):
 
             predictions = []
 
-            bar = progressbar.ProgressBar(max_value=step_count,
-                                          prefix='Decoding predictions | ',
-                                          fd=sys.stdout).start()
+            bar = create_progressbar(max_value=step_count,
+                                     prefix='Decoding predictions | ').start()
+            log_progress('Decoding predictions...')
 
             # Second pass, decode logits and compute WER and edit distance metrics
             for logits, seq_length in bar(zip(logitses, seq_lengths)):

--- a/util/feeding.py
+++ b/util/feeding.py
@@ -63,7 +63,7 @@ def to_sparse_tuple(sequence):
     return indices, sequence, shape
 
 
-def create_dataset(csvs, batch_size, cache_path):
+def create_dataset(csvs, batch_size, cache_path=''):
     df = read_csvs(csvs)
     df.sort_values(by='wav_filesize', inplace=True)
 

--- a/util/flags.py
+++ b/util/flags.py
@@ -17,7 +17,6 @@ def create_flags():
     f.DEFINE_string('test_files', '', 'comma separated list of files specifying the dataset used for testing. Multiple files will get merged. If empty, the model will not be tested.')
 
     f.DEFINE_string('train_cached_features_path', '', 'comma separated list of files specifying the dataset used for training. multiple files will get merged')
-    f.DEFINE_string('test_cached_features_path', '', 'comma separated list of files specifying the dataset used for testing. multiple files will get merged')
 
     f.DEFINE_integer('feature_win_len', 32, 'feature extraction audio window length in milliseconds')
     f.DEFINE_integer('feature_win_step', 20, 'feature extraction window step length in milliseconds')

--- a/util/flags.py
+++ b/util/flags.py
@@ -17,7 +17,6 @@ def create_flags():
     f.DEFINE_string('test_files', '', 'comma separated list of files specifying the dataset used for testing. Multiple files will get merged. If empty, the model will not be tested.')
 
     f.DEFINE_string('train_cached_features_path', '', 'comma separated list of files specifying the dataset used for training. multiple files will get merged')
-    f.DEFINE_string('dev_cached_features_path', '', 'comma separated list of files specifying the dataset used for validation. multiple files will get merged')
     f.DEFINE_string('test_cached_features_path', '', 'comma separated list of files specifying the dataset used for testing. multiple files will get merged')
 
     f.DEFINE_integer('feature_win_len', 32, 'feature extraction audio window length in milliseconds')

--- a/util/flags.py
+++ b/util/flags.py
@@ -16,7 +16,7 @@ def create_flags():
     f.DEFINE_string('dev_files', '', 'comma separated list of files specifying the dataset used for validation. Multiple files will get merged. If empty, validation will not be run.')
     f.DEFINE_string('test_files', '', 'comma separated list of files specifying the dataset used for testing. Multiple files will get merged. If empty, the model will not be tested.')
 
-    f.DEFINE_string('train_cached_features_path', '', 'comma separated list of files specifying the dataset used for training. multiple files will get merged')
+    f.DEFINE_string('feature_cache', '', 'path where cached features extracted from --train_files will be saved. If empty, caching will be done in memory and no files will be written.')
 
     f.DEFINE_integer('feature_win_len', 32, 'feature extraction audio window length in milliseconds')
     f.DEFINE_integer('feature_win_step', 20, 'feature extraction window step length in milliseconds')

--- a/util/logging.py
+++ b/util/logging.py
@@ -1,5 +1,8 @@
 from __future__ import print_function
 
+import progressbar
+import sys
+
 from util.flags import FLAGS
 
 
@@ -28,3 +31,19 @@ def log_warn(message):
 def log_error(message):
     if FLAGS.log_level <= 3:
         prefix_print('E ', message)
+
+
+def create_progressbar(*args, **kwargs):
+    # Progress bars in stdout by default
+    if 'fd' not in kwargs:
+        kwargs['fd'] = sys.stdout
+
+    if FLAGS.show_progressbar:
+        return progressbar.ProgressBar(*args, **kwargs)
+
+    return progressbar.NullBar(*args, **kwargs)
+
+
+def log_progress(message):
+    if not FLAGS.show_progressbar:
+        log_info(message)


### PR DESCRIPTION
As a consequence this also removes support for caching to disk the processed validation and test sets. They're usually small enough that caching to disk makes very little difference, and the complexity of keeping track of multiple cache paths for each CSV is not worth it IMO.

Sorry for the continued churn on the progress bar/logging part of the code. This PR also includes some cleanup of that code using `progressbar.NullBar` so that there's now a single check for the `--show_progressbar` flag. With this PR, the log with and without progress bars should be consistent in the information it provides.

I recommend disabling whitespace changes for reviewing the last commit that touches `evaluate.py`, otherwise the diff ends up looking like a mess.