### PR TITLE
Fix spaces being appended to word

### DIFF
--- a/native_client/client.cc
+++ b/native_client/client.cc
@@ -269,7 +269,7 @@ WordsFromMetadata(Metadata* metadata)
 
     // Append character to word if it's not a space
     if (strcmp(item.character, " ") != 0 
-        || strcmp(item.character, u8"　") != 0) {
+        && strcmp(item.character, u8"　") != 0) {
       word.append(item.character);
     }
 


### PR DESCRIPTION
I spotted a bug in the WordsFromMetadata function in the client. It should be "if it's not a space AND if it's not a UTF8 space", otherwise you still get the space appended to the word.