### PR TITLE
Change wrong BEAM_WIDTH .NET console client

### DIFF
--- a/native_client/dotnet/DeepSpeechConsole/Program.cs
+++ b/native_client/dotnet/DeepSpeechConsole/Program.cs
@@ -52,7 +52,7 @@ namespace CSharpExamples
 
             const uint N_CEP = 26;
             const uint N_CONTEXT = 9;
-            const uint BEAM_WIDTH = 200;
+            const uint BEAM_WIDTH = 500;
             const float LM_ALPHA = 0.75f;
             const float LM_BETA = 1.85f;
 


### PR DESCRIPTION
Related to different transcriptions between platforms.

https://discourse.mozilla.org/t/compiling-the-0-4-1-client-on-windows/38345/5