### PR TITLE
Ensure proper cleanup on macOS workers

### DIFF
--- a/taskcluster/darwin-opt-base.tyml
+++ b/taskcluster/darwin-opt-base.tyml
@@ -88,6 +88,10 @@ payload:
         export MACOSX_DEPLOYMENT_TARGET=10.10 &&
         export HOMEBREW_NO_AUTO_UPDATE=1 &&
         env &&
+        trap "export TASKCLUSTER_TASK_EXIT_CODE=$? &&
+        mv $TASKCLUSTER_TASK_DIR/homebrew/ $TASKCLUSTER_ORIG_TASKDIR/homebrew/ &&
+        mv $TASKCLUSTER_TASK_DIR/homebrew.cache/ $TASKCLUSTER_ORIG_TASKDIR/homebrew.cache/ &&
+        cd $TASKCLUSTER_TASK_DIR/../ && rm -fr tc-workdir/ && exit $TASKCLUSTER_TASK_EXIT_CODE" EXIT &&
         (wget -O - $TENSORFLOW_BUILD_ARTIFACT | pixz -d | gtar -C $TASKCLUSTER_TASK_DIR -xf - ) &&
         git clone --quiet ${event.head.repo.url} $TASKCLUSTER_TASK_DIR/DeepSpeech/ds/ &&
         cd $TASKCLUSTER_TASK_DIR/DeepSpeech/ds && git checkout --quiet ${event.head.sha} &&
@@ -96,11 +100,7 @@ payload:
         $TASKCLUSTER_TASK_DIR/DeepSpeech/tf/tc-brew.sh &&
         ${swig.patch_nodejs.osx_v12} &&
         $TASKCLUSTER_TASK_DIR/DeepSpeech/ds/${build.scripts.build} &&
-        $TASKCLUSTER_TASK_DIR/DeepSpeech/ds/${build.scripts.package} ;
-        export TASKCLUSTER_TASK_EXIT_CODE=$? &&
-        mv $TASKCLUSTER_TASK_DIR/homebrew/ $TASKCLUSTER_ORIG_TASKDIR/homebrew/ &&
-        mv $TASKCLUSTER_TASK_DIR/homebrew.cache/ $TASKCLUSTER_ORIG_TASKDIR/homebrew.cache/ &&
-        cd $TASKCLUSTER_TASK_DIR/../ && rm -fr tc-workdir/ && exit $TASKCLUSTER_TASK_EXIT_CODE
+        $TASKCLUSTER_TASK_DIR/DeepSpeech/ds/${build.scripts.package}
 
   artifacts:
     - type: "directory"

--- a/taskcluster/test-darwin-opt-base.tyml
+++ b/taskcluster/test-darwin-opt-base.tyml
@@ -62,15 +62,15 @@ then:
             export HOMEBREW_NO_AUTO_UPDATE=1 &&
             export PIP_DEFAULT_TIMEOUT=60 &&
             env &&
+            trap "export TASKCLUSTER_TASK_EXIT_CODE=$? &&
+            mv $TASKCLUSTER_TASK_DIR/homebrew/ $TASKCLUSTER_ORIG_TASKDIR/homebrew/ &&
+            mv $TASKCLUSTER_TASK_DIR/homebrew.cache/ $TASKCLUSTER_ORIG_TASKDIR/homebrew.cache/ &&
+            cd $TASKCLUSTER_TASK_DIR/../ && rm -fr tc-workdir/ && exit $TASKCLUSTER_TASK_EXIT_CODE" EXIT &&
             git clone --quiet ${event.head.repo.url} $TASKCLUSTER_TASK_DIR/DeepSpeech/ds/ &&
             cd $TASKCLUSTER_TASK_DIR/DeepSpeech/ds && git checkout --quiet ${event.head.sha} &&
             cd $TASKCLUSTER_TASK_DIR &&
             source $TASKCLUSTER_TASK_DIR/DeepSpeech/ds/tc-brew-tests.sh && ${extraSystemSetup} &&
-            /bin/bash ${build.args.tests_cmdline} ;
-            export TASKCLUSTER_TASK_EXIT_CODE=$? &&
-            mv $TASKCLUSTER_TASK_DIR/homebrew/ $TASKCLUSTER_ORIG_TASKDIR/homebrew/ &&
-            mv $TASKCLUSTER_TASK_DIR/homebrew.cache/ $TASKCLUSTER_ORIG_TASKDIR/homebrew.cache/ &&
-            cd $TASKCLUSTER_TASK_DIR/../ && rm -fr tc-workdir/ && exit $TASKCLUSTER_TASK_EXIT_CODE
+            /bin/bash ${build.args.tests_cmdline}
 
     mounts:
       - cacheName: deepspeech-homebrew-bin


### PR DESCRIPTION
It seems like `-e` does is job and bash catches faulty exit code, thus
avoiding the required `mv` for dealing with caches. Doing it in a second
command should help