### PR TITLE
Update to Homebrew 2.1.6

### DIFF
--- a/taskcluster/tc-brew-tests.sh
+++ b/taskcluster/tc-brew-tests.sh
@@ -37,7 +37,7 @@ install_local_homebrew()
     mkdir -p "${LOCAL_HOMEBREW_DIRECTORY}"
     mkdir -p "${HOMEBREW_CACHE}"
 
-    curl -L https://github.com/Homebrew/brew/tarball/1.8.0 | tar xz --strip 1 -C "${LOCAL_HOMEBREW_DIRECTORY}"
+    curl -L https://github.com/Homebrew/brew/tarball/2.1.6 | tar xz --strip 1 -C "${LOCAL_HOMEBREW_DIRECTORY}"
     export PATH=${LOCAL_HOMEBREW_DIRECTORY}/bin:$PATH
 
     if [ ! -x "${LOCAL_HOMEBREW_DIRECTORY}/bin/brew" ]; then


### PR DESCRIPTION
Trying a fix for our recent macOS failures. The way Homebrew works isn't particularly suitable to pinning a version, as brew will clone its dependencies from master regardless of what version it's running. Trying the latest release to see if things explode.