### PR TITLE
Resampling to 16khz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,6 @@ soundfile
 paramiko >= 2.1
 scipy
 matplotlib
+
+#Data augmentation and resampling
+librosa==0.7

--- a/util/flags.py
+++ b/util/flags.py
@@ -27,7 +27,7 @@ def create_flags():
 
     f.DEFINE_integer('epochs', 75, 'how many epochs (complete runs through the train files) to train for')
 
-    f.DEFINE_float('dropout_rate', 0.05, 'dropout rate for feedforward layers')
+    f.DEFINE_float('dropout_rate', 0.225, 'dropout rate for feedforward layers')
     f.DEFINE_float('dropout_rate2', -1.0, 'dropout rate for layer 2 - defaults to dropout_rate')
     f.DEFINE_float('dropout_rate3', -1.0, 'dropout rate for layer 3 - defaults to dropout_rate')
     f.DEFINE_float('dropout_rate4', 0.0, 'dropout rate for layer 4 - defaults to 0.0')
@@ -45,9 +45,9 @@ def create_flags():
 
     # Batch sizes
 
-    f.DEFINE_integer('train_batch_size', 1, 'number of elements in a training batch')
-    f.DEFINE_integer('dev_batch_size', 1, 'number of elements in a validation batch')
-    f.DEFINE_integer('test_batch_size', 1, 'number of elements in a test batch')
+    f.DEFINE_integer('train_batch_size', 64, 'number of elements in a training batch')
+    f.DEFINE_integer('dev_batch_size', 64, 'number of elements in a validation batch')
+    f.DEFINE_integer('test_batch_size', 64, 'number of elements in a test batch')
 
     f.DEFINE_integer('export_batch_size', 1, 'number of elements per batch on the exported graph')
 


### PR DESCRIPTION
Resampling audio files to 16khz if dataset has any other sampling rate. 



I tried exporting models trained on 44100 and 22050 khz and it throws the ambiguous shape error as observed in this thread.
https://discourse.mozilla.org/t/trained-model-on-my-own-data/41810/42
I understand that the python client only supports 16khz currently, so I thought we could just resample the dataset to 16khz if the files are not in 16khz and then train it.

The Time consumption overhead is minimal. I've tested the code on 44.1khz dataset. 

