### PR TITLE
Label validation - Replace hyphens with spaces

### DIFF
--- a/util/text.py
+++ b/util/text.py
@@ -92,8 +92,9 @@ def validate_label(label):
     if re.search(r"[0-9]|[(<\[\]&*{]", label) is not None:
         return None
 
-    label = label.replace("-", "")
-    label = label.replace("_", "")
+    label = label.replace("-", " ")
+    label = label.replace("_", " ")
+    label = re.sub("[ ]{2,}", " ", label)
     label = label.replace(".", "")
     label = label.replace(",", "")
     label = label.replace("?", "")


### PR DESCRIPTION
I noticed when checking some of the files in the Common Voice dataset that there were situations like the following:

> Expected transcript: beall and the endall
> Actual transcript: be all and the end all

DeepSpeech actually got the transcription perfect, but it's still counted as inaccurate because the importer script stripped out the hyphen separating those words.

It also seems to cause issues with numbers, with `nineteen-sixty-nine` becoming `nineteensixtynine`.

This PR replaces hyphens with spaces and adds a regex for safety to strip out any double spaces that may occur as a result.