### PR TITLE
Only update time step of leaf prefixes (Fixes #2294)

### DIFF
--- a/native_client/ctcdecode/path_trie.cpp
+++ b/native_client/ctcdecode/path_trie.cpp
@@ -39,7 +39,12 @@ PathTrie* PathTrie::get_path_trie(int new_char, int new_timestep, float cur_log_
   auto child = children_.begin();
   for (child = children_.begin(); child != children_.end(); ++child) {
     if (child->first == new_char) {
-      if (child->second->log_prob_c < cur_log_prob_c) {
+      // If existing child matches this new_char but had a lower probability,
+      // and it's a leaf, update its timestep to new_timestep.
+      // The leak check makes sure we don't update the child to have a later
+      // timestep than a grandchild.
+      if (child->second->log_prob_c < cur_log_prob_c &&
+          child->second->children_.size() == 0) {
         child->second->log_prob_c = cur_log_prob_c;
         child->second->timestep = new_timestep;
       }
@@ -54,7 +59,7 @@ PathTrie* PathTrie::get_path_trie(int new_char, int new_timestep, float cur_log_
       child->second->log_prob_b_cur = -NUM_FLT_INF;
       child->second->log_prob_nb_cur = -NUM_FLT_INF;
     }
-    return (child->second);
+    return child->second;
   } else {
     if (has_dictionary_) {
       matcher_->SetState(dictionary_state_);
@@ -145,9 +150,7 @@ void PathTrie::remove() {
   exists_ = false;
 
   if (children_.size() == 0) {
-    auto child = parent->children_.begin();
-    for (child = parent->children_.begin(); child != parent->children_.end();
-         ++child) {
+    for (auto child = parent->children_.begin(); child != parent->children_.end(); ++child) {
       if (child->first == character) {
         parent->children_.erase(child);
         break;


### PR DESCRIPTION
The intention of this check is to improve the accuracy of the timings by recording the time step where the character saw its highest probability rather than the first time step where it was seen. The problem happens when updating the time step of a prefix that already has children. In that case, if any of the children have a time step that is earlier than `new_timestep`, it'll break the linearity of the timings. My fix is to simply check that the prefix we're updating is a leaf.

For example, say during decoding we have the following beams (format is `(char | time)`, tree node id below, nodes with same id are the same object):

```
1. (-1 | 0 ) -> ('s' | 10) -> ('h' | 13) -> ('e' | 14)
       A             B             C             D

2. (-1 | 0 ) -> ('s' | 10) -> ('h' | 14)
       A             B             E
```

And the prefix list is `[B, C, D, E]`. Currently, if we process character 'h' in time step 15 with a probability higher than both C and E, we update both nodes to have time step 15, which breaks linearity in beam 1. With my fix, we only update node E, which is a leaf. In my tests this does fix the problem, but since we don't have any known good quality data to verify against, it's hard to know if it has other side effects.