### PR TITLE
Add WPF example build

### DIFF
--- a/taskcluster/tc-tests-utils.sh
+++ b/taskcluster/tc-tests-utils.sh
@@ -915,6 +915,25 @@ do_deepspeech_netframework_build()
     /p:Platform=x64
 }
 
+do_deepspeech_netframework_wpf_example_build()
+{
+  cd ${DS_DSDIR}/examples/net_framework
+
+  # Setup dependencies
+  nuget install DeepSpeechWPF/packages.config -OutputDirectory DeepSpeechWPF/packages/
+
+  MSBUILD="$(cygpath 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\MSBuild.exe')"
+
+  # We need MSYS2_ARG_CONV_EXCL='/' otherwise the '/' of CLI parameters gets mangled and disappears
+  # Build WPF example
+  MSYS2_ARG_CONV_EXCL='/' "${MSBUILD}" \
+    DeepSpeechWPF/DeepSpeech.WPF.csproj \
+    /p:Configuration=Release \
+    /p:Platform=x64 \
+    /p:OutputPath=bin/x64
+
+}
+
 do_nuget_build()
 {
   PROJECT_NAME=$1

--- a/taskcluster/win-build.sh
+++ b/taskcluster/win-build.sh
@@ -47,6 +47,8 @@ do_deepspeech_nodejs_build "${cuda}"
 
 do_deepspeech_netframework_build
 
+do_deepspeech_netframework_wpf_example_build
+
 do_nuget_build "${PROJECT_NAME}"
 
 shutdown_bazel


### PR DESCRIPTION
We need to build the WPF example to check any inconsistency with the client. Introduced the usage of `/t:Rebuild` to clean/build always and avoid any weird behavior from cached files.