### PR TITLE
Fixed issue where multiple csvs could not load

### DIFF
--- a/util/feeding.py
+++ b/util/feeding.py
@@ -27,7 +27,7 @@ def read_csvs(csv_files):
         if source_data is None:
             source_data = file
         else:
-            source_data = source_data.append(file)
+            source_data = source_data.append(file, ignore_index=True)
     return source_data
 
 


### PR DESCRIPTION
With the new `create_dataset` approach introduced by PR #2283 (read: mine, sorry!), duplicate
indices in the df would cause a fatal error where the columns could not be referenced by
name. Adding `ignore_index=True` during append allows pandas to assign new indices to
rows, and fixes the issue.