### PR TITLE
C compatibility

### DIFF
--- a/native_client/deepspeech.h
+++ b/native_client/deepspeech.h
@@ -7,10 +7,10 @@ extern "C" {
 
 #ifndef SWIG
     #if defined _MSC_VER
-        #define DEEPSPEECH_EXPORT __declspec(dllexport) 
-    #else                                                                   /*End of _MSC_VER*/  
+        #define DEEPSPEECH_EXPORT __declspec(dllexport)
+    #else                                                                   /*End of _MSC_VER*/
         #define DEEPSPEECH_EXPORT __attribute__ ((visibility("default")))
-#endif                                                                      /*End of SWIG*/  
+#endif                                                                      /*End of SWIG*/
 #else
     #define DEEPSPEECH_EXPORT
 #endif

--- a/native_client/deepspeech.h
+++ b/native_client/deepspeech.h
@@ -1,11 +1,15 @@
 #ifndef DEEPSPEECH_H
 #define DEEPSPEECH_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #ifndef SWIG
     #if defined _MSC_VER
-        #define DEEPSPEECH_EXPORT extern "C" __declspec(dllexport) 
+        #define DEEPSPEECH_EXPORT __declspec(dllexport) 
     #else                                                                   /*End of _MSC_VER*/  
-        #define DEEPSPEECH_EXPORT extern "C" __attribute__ ((visibility("default")))
+        #define DEEPSPEECH_EXPORT __attribute__ ((visibility("default")))
 #endif                                                                      /*End of SWIG*/  
 #else
     #define DEEPSPEECH_EXPORT
@@ -252,5 +256,9 @@ DEEPSPEECH_EXPORT
 void DS_PrintVersions();
 
 #undef DEEPSPEECH_EXPORT
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* DEEPSPEECH_H */

--- a/native_client/deepspeech.h
+++ b/native_client/deepspeech.h
@@ -15,24 +15,24 @@ extern "C" {
     #define DEEPSPEECH_EXPORT
 #endif
 
-struct ModelState;
+typedef struct ModelState ModelState;
 
-struct StreamingState;
+typedef struct StreamingState StreamingState;
 
 // Stores each individual character, along with its timing information
-struct MetadataItem {
+typedef struct MetadataItem {
   char* character;
   int timestep; // Position of the character in units of 20ms
   float start_time; // Position of the character in seconds
-};
+} MetadataItem;
 
 // Stores the entire CTC output as an array of character metadata objects
-struct Metadata {
+typedef struct Metadata {
   MetadataItem* items;
   int num_items;
   // Approximated probability (confidence value) for this transcription.
   double probability;
-};
+} Metadata;
 
 enum DeepSpeech_Error_Codes
 {


### PR DESCRIPTION
Currently it is not possible to use `deepspeech.h` in a project written in C, since there are compilation errors related to the use of `extern "C"` and missing struct keywords/typedefs.

With the following changes, I am able to use `native_client` in both C and C++ projects:

- Wrap the header in `extern "C"`, only when compiling as C++.
- Use `typedef` for structs so that they can be used without the `struct` tag.

I also removed trailing whitespace from the header.  I can rebase out that change if needed.