### PR TITLE
Fixes bug of allocating full gpu memory

### DIFF
--- a/util/config.py
+++ b/util/config.py
@@ -27,15 +27,9 @@ Config = ConfigSingleton() # pylint: disable=invalid-name
 def initialize_globals():
     c = AttrDict()
 
-    # CPU device
-    c.cpu_device = '/cpu:0'
 
-    # Available GPU devices
-    c.available_devices = get_available_gpus()
 
-    # If there is no GPU available, we fall back to CPU based operation
-    if not c.available_devices:
-        c.available_devices = [c.cpu_device]
+
 
     # Set default dropout rates
     if FLAGS.dropout_rate2 < 0:
@@ -59,7 +53,22 @@ def initialize_globals():
     # Standard session configuration that'll be used for all new sessions.
     c.session_config = tf.ConfigProto(allow_soft_placement=True, log_device_placement=FLAGS.log_placement,
                                       inter_op_parallelism_threads=FLAGS.inter_op_parallelism_threads,
-                                      intra_op_parallelism_threads=FLAGS.intra_op_parallelism_threads)
+                                      intra_op_parallelism_threads=FLAGS.intra_op_parallelism_threads,
+                                      gpu_options=tf.GPUOptions(allow_growth=True))
+
+    # CPU device
+    c.cpu_device = '/cpu:0'
+
+    # Available GPU devices
+    c.available_devices = get_available_gpus(c.session_config)
+
+    # If there is no GPU available, we fall back to CPU based operation
+    if not c.available_devices:
+        c.available_devices = [c.cpu_device]
+        # Standard session configuration that'll be used for all new sessions.
+        c.session_config = tf.ConfigProto(allow_soft_placement=True, log_device_placement=FLAGS.log_placement,
+                                          inter_op_parallelism_threads=FLAGS.inter_op_parallelism_threads,
+                                          intra_op_parallelism_threads=FLAGS.intra_op_parallelism_threads)
 
     c.alphabet = Alphabet(os.path.abspath(FLAGS.alphabet_config_path))
 

--- a/util/config.py
+++ b/util/config.py
@@ -54,7 +54,7 @@ def initialize_globals():
     c.session_config = tf.ConfigProto(allow_soft_placement=True, log_device_placement=FLAGS.log_placement,
                                       inter_op_parallelism_threads=FLAGS.inter_op_parallelism_threads,
                                       intra_op_parallelism_threads=FLAGS.intra_op_parallelism_threads,
-                                      gpu_options=tf.GPUOptions(allow_growth=True))
+                                      gpu_options=tf.GPUOptions(allow_growth=FLAGS.use_allow_growth))
 
     # CPU device
     c.cpu_device = '/cpu:0'

--- a/util/flags.py
+++ b/util/flags.py
@@ -55,6 +55,7 @@ def create_flags():
 
     f.DEFINE_integer('inter_op_parallelism_threads', 0, 'number of inter-op parallelism threads - see tf.ConfigProto for more details. USE OF THIS FLAG IS UNSUPPORTED')
     f.DEFINE_integer('intra_op_parallelism_threads', 0, 'number of intra-op parallelism threads - see tf.ConfigProto for more details. USE OF THIS FLAG IS UNSUPPORTED')
+    f.DEFINE_boolean('use_allow_growth', False, 'use Allow Growth flag which will allocate only required amount of GPU memory and prevent full allocation of available GPU memory')
     f.DEFINE_boolean('use_cudnn_rnn', False, 'use CuDNN RNN backend for training on GPU. Note that checkpoints created with this flag can only be used with CuDNN RNN, i.e. fine tuning on a CPU device will not work')
     f.DEFINE_string('cudnn_checkpoint', '', 'path to a checkpoint created using --use_cudnn_rnn. Specifying this flag allows one to convert a CuDNN RNN checkpoint to a checkpoint capable of running on a CPU graph.')
 

--- a/util/gpu.py
+++ b/util/gpu.py
@@ -1,6 +1,7 @@
 from tensorflow.python.client import device_lib
 
-def get_available_gpus():
+
+def get_available_gpus(config):
     r"""
     Returns the number of GPUs available on this system.
     """

--- a/util/gpu.py
+++ b/util/gpu.py
@@ -5,5 +5,5 @@ def get_available_gpus(config):
     r"""
     Returns the number of GPUs available on this system.
     """
-    local_device_protos = device_lib.list_local_devices()
+    local_device_protos = device_lib.list_local_devices(session_config=config)
     return [x.name for x in local_device_protos if x.device_type == 'GPU']


### PR DESCRIPTION
After call to gpu list_local_devices, tensorflow allocates all gpu available memory which in turn block concurrent trainings. To solve this we need to pass seesion config to list_local_device function after adding allow_growth=True.