### PR TITLE
Set forget_bias=0 in CPU graph for compatibility with CudnnRNN

### DIFF
--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -82,6 +82,7 @@ def dense(name, x, units, dropout_rate=None, relu=True):
 def rnn_impl_lstmblockfusedcell(x, seq_length, previous_state, reuse):
     with tfv1.variable_scope('cudnn_lstm/rnn/multi_rnn_cell/cell_0'):
         fw_cell = tf.contrib.rnn.LSTMBlockFusedCell(Config.n_cell_dim,
+                                                    forget_bias=0,
                                                     reuse=reuse,
                                                     name='cudnn_compatible_lstm_cell')
 


### PR DESCRIPTION
In my tests this fixes the discrepancy between results with and without CudnnRNN. Tilman, can you verify this does the right thing for you too?