### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -144,6 +144,7 @@ COPY . /DeepSpeech/
 # Alternative clone from GitHub 
 # RUN apt-get update && apt-get install -y git-lfs 
 # WORKDIR /
+# RUN git lfs install
 # RUN git clone https://github.com/mozilla/DeepSpeech.git
 
 WORKDIR /DeepSpeech


### PR DESCRIPTION
Added line to initialise git-lfs before cloning the repo, without this command lm.binary doesn't pull. If we want this to be versions specific, might also be worth doing a git checkout <version>