### PR TITLE
Expose cutoff_prob and cutoff_top_n as parameters of libdeepspeech.so

### DIFF
--- a/native_client/deepspeech.cc
+++ b/native_client/deepspeech.cc
@@ -324,7 +324,9 @@ DS_EnableDecoderWithLM(ModelState* aCtx,
 
 int
 DS_CreateStream(ModelState* aCtx,
-                StreamingState** retval)
+                StreamingState** retval,
+                int cutoff_top_n,
+                double cutoff_prob)
 {
   *retval = nullptr;
 
@@ -341,9 +343,6 @@ DS_CreateStream(ModelState* aCtx,
   ctx->previous_state_c_.resize(aCtx->state_size_, 0.f);
   ctx->previous_state_h_.resize(aCtx->state_size_, 0.f);
   ctx->model_ = aCtx;
-
-  const int cutoff_top_n = 40;
-  const double cutoff_prob = 1.0;
 
   ctx->decoder_state_.init(aCtx->alphabet_,
                            aCtx->beam_width_,
@@ -388,10 +387,12 @@ DS_FinishStreamWithMetadata(StreamingState* aSctx)
 StreamingState*
 CreateStreamAndFeedAudioContent(ModelState* aCtx,
                                 const short* aBuffer,
-                                unsigned int aBufferSize)
+                                unsigned int aBufferSize,
+                                int cutoff_top_n,
+                                double cutoff_prob)
 {
   StreamingState* ctx;
-  int status = DS_CreateStream(aCtx, &ctx);
+  int status = DS_CreateStream(aCtx, &ctx, cutoff_top_n, cutoff_prob);
   if (status != DS_ERR_OK) {
     return nullptr;
   }
@@ -402,18 +403,24 @@ CreateStreamAndFeedAudioContent(ModelState* aCtx,
 char*
 DS_SpeechToText(ModelState* aCtx,
                 const short* aBuffer,
-                unsigned int aBufferSize)
+                unsigned int aBufferSize,
+                int cutoff_top_n,
+                double cutoff_prob)
 {
-  StreamingState* ctx = CreateStreamAndFeedAudioContent(aCtx, aBuffer, aBufferSize);
+  StreamingState* ctx = CreateStreamAndFeedAudioContent(aCtx, aBuffer, aBufferSize,
+                                                        cutoff_top_n, cutoff_prob);
   return DS_FinishStream(ctx);
 }
 
 Metadata*
 DS_SpeechToTextWithMetadata(ModelState* aCtx,
                             const short* aBuffer,
-                            unsigned int aBufferSize)
+                            unsigned int aBufferSize,
+                            int cutoff_top_n,
+                            double cutoff_prob)
 {
-  StreamingState* ctx = CreateStreamAndFeedAudioContent(aCtx, aBuffer, aBufferSize);
+  StreamingState* ctx = CreateStreamAndFeedAudioContent(aCtx, aBuffer, aBufferSize,
+                                                        cutoff_top_n, cutoff_prob);
   return DS_FinishStreamWithMetadata(ctx);
 }
 

--- a/native_client/deepspeech.h
+++ b/native_client/deepspeech.h
@@ -136,6 +136,8 @@ int DS_EnableDecoderWithLM(ModelState* aCtx,
  * @param aBuffer A 16-bit, mono raw audio signal at the appropriate
  *                sample rate (matching what the model was trained on).
  * @param aBufferSize The number of samples in the audio signal.
+ * @param cutoff_top_n Cutoff probability for pruning.
+ * @param cutoff_prob Cutoff number for pruning.
  *
  * @return The STT result. The user is responsible for freeing the string using
  *         {@link DS_FreeString()}. Returns NULL on error.
@@ -143,7 +145,9 @@ int DS_EnableDecoderWithLM(ModelState* aCtx,
 DEEPSPEECH_EXPORT
 char* DS_SpeechToText(ModelState* aCtx,
                       const short* aBuffer,
-                      unsigned int aBufferSize);
+                      unsigned int aBufferSize,
+                      int cutoff_top_n = 40,
+                      double cutoff_prob = 1.0);
 
 /**
  * @brief Use the DeepSpeech model to perform Speech-To-Text and output metadata 
@@ -153,6 +157,8 @@ char* DS_SpeechToText(ModelState* aCtx,
  * @param aBuffer A 16-bit, mono raw audio signal at the appropriate
  *                sample rate (matching what the model was trained on).
  * @param aBufferSize The number of samples in the audio signal.
+ * @param cutoff_top_n Cutoff probability for pruning.
+ * @param cutoff_prob Cutoff number for pruning.
  *
  * @return Outputs a struct of individual letters along with their timing information. 
  *         The user is responsible for freeing Metadata by calling {@link DS_FreeMetadata()}. Returns NULL on error.
@@ -160,7 +166,9 @@ char* DS_SpeechToText(ModelState* aCtx,
 DEEPSPEECH_EXPORT
 Metadata* DS_SpeechToTextWithMetadata(ModelState* aCtx,
                                       const short* aBuffer,
-                                      unsigned int aBufferSize);
+                                      unsigned int aBufferSize,
+                                      int cutoff_top_n = 40,
+                                      double cutoff_prob = 1.0);
 
 /**
  * @brief Create a new streaming inference state. The streaming state returned
@@ -170,12 +178,16 @@ Metadata* DS_SpeechToTextWithMetadata(ModelState* aCtx,
  * @param aCtx The ModelState pointer for the model to use.
  * @param[out] retval an opaque pointer that represents the streaming state. Can
  *                    be NULL if an error occurs.
+ * @param cutoff_top_n Cutoff probability for pruning.
+ * @param cutoff_prob Cutoff number for pruning.
  *
  * @return Zero for success, non-zero on failure.
  */
 DEEPSPEECH_EXPORT
 int DS_CreateStream(ModelState* aCtx,
-                    StreamingState** retval);
+                    StreamingState** retval,
+                    int cutoff_top_n = 40,
+                    double cutoff_prob = 1.0);
 
 /**
  * @brief Feed audio samples to an ongoing streaming inference.


### PR DESCRIPTION
As well as PR #2453, I exposed `cutoff_prob` and `cutoff_top_n` on libdeepspeech.so.
These parameters are very important when we support languages having many characters (i.e. Chinese or Japanese).
