### PR TITLE
added alias for trie,alphabet,lm_binary in util/flags to match module

### DIFF
--- a/util/flags.py
+++ b/util/flags.py
@@ -133,8 +133,11 @@ def create_flags():
     # Decoder
 
     f.DEFINE_string('alphabet_config_path', 'data/alphabet.txt', 'path to the configuration file specifying the alphabet used by the network. See the comment in data/alphabet.txt for a description of the format.')
+    f.DEFINE_alias('alphabet', 'alphabet_config_path')
     f.DEFINE_string('lm_binary_path', 'data/lm/lm.binary', 'path to the language model binary file created with KenLM')
+    f.DEFINE_alias('lm', 'lm_binary_path')
     f.DEFINE_string('lm_trie_path', 'data/lm/trie', 'path to the language model trie file created with native_client/generate_trie')
+    f.DEFINE_alias('trie', 'lm_trie_path')
     f.DEFINE_integer('beam_width', 1024, 'beam width used in the CTC decoder when building candidate transcriptions')
     f.DEFINE_float('lm_alpha', 0.75, 'the alpha hyperparameter of the CTC decoder. Language Model weight.')
     f.DEFINE_float('lm_beta', 1.85, 'the beta hyperparameter of the CTC decoder. Word insertion weight.')


### PR DESCRIPTION


This adds alias according to $deepspeech --lm --trie --alphabet
with DeepSpeech.py and evaluate.py that use other names for the same flags