### PR TITLE
Bug 1574659: migrate from tasckluster.net to community-tc

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,8 +7,8 @@ metadata:
   owner: "{{ event.head.user.email }}" # the user who sent the pr/push e-mail will be inserted here
   source: "{{ event.head.repo.url }}"  # the repo where the pr came from will be inserted here
 tasks:
-  - provisionerId: "{{ taskcluster.docker.provisionerId }}"
-    workerType: "deepspeech-worker"
+  - provisionerId: "proj-deepspeech"
+    workerType: "ci"
     extra:
       github:
         env: true
@@ -25,13 +25,8 @@ tasks:
       - "notify.irc-channel.#machinelearning.on-any"
 
     scopes: [
-      "queue:create-task:lowest:{{ taskcluster.docker.provisionerId }}/deepspeech-worker",
-      "queue:create-task:lowest:{{ taskcluster.docker.provisionerId }}/deepspeech-win-b",
-      "queue:create-task:lowest:{{ taskcluster.docker.provisionerId }}/deepspeech-kvm-worker",
-      "queue:create-task:lowest:deepspeech-provisioner/ds-macos-light",
-      "queue:create-task:lowest:deepspeech-provisioner/ds-scriptworker",
-      "queue:create-task:lowest:deepspeech-provisioner/ds-rpi3",
-      "queue:create-task:lowest:deepspeech-provisioner/ds-lepotato",
+      "queue:create-task:highest:proj-deepspeech/*",
+      "queue:create-task:lowest:proj-deepspeech/*",
       "queue:route:index.project.deepspeech.*",
       "queue:route:notify.irc-channel.*",
       "queue:scheduler-id:taskcluster-github",

--- a/README.rst
+++ b/README.rst
@@ -7,8 +7,8 @@ Project DeepSpeech
    :alt: Documentation
 
 
-.. image:: https://github.taskcluster.net/v1/repository/mozilla/DeepSpeech/master/badge.svg
-   :target: https://github.taskcluster.net/v1/repository/mozilla/DeepSpeech/master/latest
+.. image:: https://community-tc.services.mozilla.com/github/v1/repository/mozilla/DeepSpeech/master/badge.svg
+   :target: https://community-tc.services.mozilla.com/github/v1/repository/mozilla/DeepSpeech/master/latest
    :alt: Task Status
 
 

--- a/examples/tests.sh
+++ b/examples/tests.sh
@@ -6,7 +6,7 @@ THIS=$(dirname "$0")
 
 source ../../taskcluster/tc-tests-utils.sh
 
-DEP_TASK_ID=$(curl -s https://queue.taskcluster.net/v1/task/${TASK_ID} | python -c 'import json; import sys; print(" ".join(json.loads(sys.stdin.read())["dependencies"]));')
+DEP_TASK_ID=$(curl -s https://community-tc.services.mozilla.com/queue/v1/task/${TASK_ID} | python -c 'import json; import sys; print(" ".join(json.loads(sys.stdin.read())["dependencies"]));')
 
 get_python_wheel_url()
 {
@@ -14,10 +14,10 @@ get_python_wheel_url()
 
   extract_python_versions "${this_python_version}" "pyver" "pyver_pkg" "py_unicode_type" "pyconf" "pyalias"
 
-  echo "$(get_python_pkg_url "${pyver_pkg}" "${py_unicode_type}" "deepspeech" https://queue.taskcluster.net/v1/task/${DEP_TASK_ID}/artifacts/public)"
+  echo "$(get_python_pkg_url "${pyver_pkg}" "${py_unicode_type}" "deepspeech" https://community-tc.services.mozilla.com/queue/v1/task/${DEP_TASK_ID}/artifacts/public)"
 }
 
 get_npm_package_url()
 {
-  echo "https://queue.taskcluster.net/v1/task/${DEP_TASK_ID}/artifacts/public/deepspeech-${DS_VERSION}.tgz"
+  echo "https://community-tc.services.mozilla.com/queue/v1/task/${DEP_TASK_ID}/artifacts/public/deepspeech-${DS_VERSION}.tgz"
 }

--- a/native_client/javascript/README.rst
+++ b/native_client/javascript/README.rst
@@ -1,7 +1,7 @@
 Project DeepSpeech
 ==================
 
-[![Task Status](https://github.taskcluster.net/v1/repository/mozilla/DeepSpeech/master/badge.svg)](https://github.taskcluster.net/v1/repository/mozilla/DeepSpeech/master/latest)
+[![Task Status](https://community-tc.services.mozilla.com/github/v1/repository/mozilla/DeepSpeech/master/badge.svg)](https://community-tc.services.mozilla.com/github/v1/repository/mozilla/DeepSpeech/master/latest)
 
 DeepSpeech is an open source Speech-To-Text engine, using a model trained by machine learning techniques based on `Baidu's Deep Speech research paper](https://arxiv.org/abs/1412.5567). Project DeepSpeech uses Google's [TensorFlow <https://www.tensorflow.org/>`_. Project DeepSpeech uses Google's `TensorFlow <https://www.tensorflow.org/>`_ to make the implementation easier.
 

--- a/native_client/javascript/package.json.in
+++ b/native_client/javascript/package.json.in
@@ -27,7 +27,7 @@
         "module_path" : "./lib/binding/v{version}/{platform}-{arch}/{node_abi}/",
         "remote_path" : "./v{version}/{configuration}/",
         "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}.tar.gz",
-        "host"        : "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.v1.0.0-warpctc.arm/artifacts/public/"
+        "host"        : "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.v1.0.0-warpctc.arm/artifacts/public/"
     },
     "dependencies"  : {
       "node-pre-gyp": "0.13.x",

--- a/taskcluster/android-arm64-cpu-opt.yml
+++ b/taskcluster/android-arm64-cpu-opt.yml
@@ -12,7 +12,7 @@ build:
   system_config:
     >
       ${swig.patch_nodejs.linux}
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.android-arm64/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.android-arm64/artifacts/public/home.tar.xz"
   scripts:
     build: "taskcluster/android-build.sh arm64-v8a"
     package: "taskcluster/android-package.sh arm64-v8a"

--- a/taskcluster/android-armv7-cpu-opt.yml
+++ b/taskcluster/android-armv7-cpu-opt.yml
@@ -12,7 +12,7 @@ build:
   system_config:
     >
       ${swig.patch_nodejs.linux}
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.android-armv7/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.android-armv7/artifacts/public/home.tar.xz"
   scripts:
     build: "taskcluster/android-build.sh armeabi-v7a"
     package: "taskcluster/android-package.sh armeabi-v7a"

--- a/taskcluster/android-java-opt.yml
+++ b/taskcluster/android-java-opt.yml
@@ -13,7 +13,7 @@ build:
   system_setup:
     >
       apt-get -qq -y install curl && ${swig.packages.install_script}
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.android-armv7/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.android-armv7/artifacts/public/home.tar.xz"
   scripts:
     build: "taskcluster/android-apk-build.sh"
     package: "taskcluster/android-apk-package.sh"

--- a/taskcluster/android-x86_64-cpu-opt.yml
+++ b/taskcluster/android-x86_64-cpu-opt.yml
@@ -12,7 +12,7 @@ build:
   system_config:
     >
       ${swig.patch_nodejs.linux}
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.android-arm64/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.android-arm64/artifacts/public/home.tar.xz"
   scripts:
     build: "taskcluster/android-build.sh x86_64"
     package: "taskcluster/android-package.sh x86_64"

--- a/taskcluster/darwin-amd64-cpu-opt.yml
+++ b/taskcluster/darwin-amd64-cpu-opt.yml
@@ -6,7 +6,7 @@ build:
     - "index.project.deepspeech.deepspeech.native_client.osx.${event.head.sha}"
     - "notify.irc-channel.${notifications.irc}.on-exception"
     - "notify.irc-channel.${notifications.irc}.on-failed"
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.osx/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.osx/artifacts/public/home.tar.xz"
   scripts:
     build: "taskcluster/host-build.sh"
     package: "taskcluster/package.sh"

--- a/taskcluster/darwin-amd64-ctc-opt.yml
+++ b/taskcluster/darwin-amd64-ctc-opt.yml
@@ -6,7 +6,7 @@ build:
     - "index.project.deepspeech.deepspeech.native_client.osx-ctc.${event.head.sha}"
     - "notify.irc-channel.${notifications.irc}.on-exception"
     - "notify.irc-channel.${notifications.irc}.on-failed"
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.osx/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.osx/artifacts/public/home.tar.xz"
   maxRunTime: 14400
   scripts:
     build: 'taskcluster/decoder-build.sh'

--- a/taskcluster/darwin-amd64-tflite-opt.yml
+++ b/taskcluster/darwin-amd64-tflite-opt.yml
@@ -6,7 +6,7 @@ build:
     - "index.project.deepspeech.deepspeech.native_client.osx-tflite.${event.head.sha}"
     - "notify.irc-channel.${notifications.irc}.on-exception"
     - "notify.irc-channel.${notifications.irc}.on-failed"
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.osx/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.osx/artifacts/public/home.tar.xz"
   scripts:
     build: "taskcluster/host-build.sh tflite"
     package: "taskcluster/package.sh"

--- a/taskcluster/darwin-opt-base.tyml
+++ b/taskcluster/darwin-opt-base.tyml
@@ -41,7 +41,7 @@ payload:
       training: { $eval: as_slugid("test-training_upstream-linux-amd64-py35m-opt") }
     in:
       TENSORFLOW_BUILD_ARTIFACT: ${build.tensorflow}
-      DEEPSPEECH_TEST_MODEL: https://queue.taskcluster.net/v1/task/${training}/artifacts/public/output_graph.pb
+      DEEPSPEECH_TEST_MODEL: https://community-tc.services.mozilla.com/queue/v1/task/${training}/artifacts/public/output_graph.pb
 
   # There is no VM yet running tasks on OSX
   # so one should install by hand:

--- a/taskcluster/linux-amd64-cpu-opt.yml
+++ b/taskcluster/linux-amd64-cpu-opt.yml
@@ -14,7 +14,7 @@ build:
   system_config:
     >
       ${swig.patch_nodejs.linux}
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.cpu/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.cpu/artifacts/public/home.tar.xz"
   scripts:
     build: "taskcluster/host-build.sh"
     package: "taskcluster/package.sh"

--- a/taskcluster/linux-amd64-ctc-opt.yml
+++ b/taskcluster/linux-amd64-ctc-opt.yml
@@ -14,7 +14,7 @@ build:
   system_config:
     >
       ${swig.patch_nodejs.linux}
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.cpu/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.cpu/artifacts/public/home.tar.xz"
   scripts:
     build: 'taskcluster/decoder-build.sh'
     package: 'taskcluster/decoder-package.sh'

--- a/taskcluster/linux-amd64-gpu-opt.yml
+++ b/taskcluster/linux-amd64-gpu-opt.yml
@@ -12,7 +12,7 @@ build:
   system_config:
     >
       ${swig.patch_nodejs.linux}
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.gpu/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.gpu/artifacts/public/home.tar.xz"
   maxRunTime: 14400
   scripts:
     build: "taskcluster/cuda-build.sh"

--- a/taskcluster/linux-amd64-tflite-opt.yml
+++ b/taskcluster/linux-amd64-tflite-opt.yml
@@ -14,7 +14,7 @@ build:
   system_config:
     >
       ${swig.patch_nodejs.linux}
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.cpu/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.cpu/artifacts/public/home.tar.xz"
   scripts:
     build: "taskcluster/host-build.sh tflite"
     package: "taskcluster/package.sh"

--- a/taskcluster/linux-arm64-cpu-opt.yml
+++ b/taskcluster/linux-arm64-cpu-opt.yml
@@ -4,7 +4,7 @@ build:
     - "index.project.deepspeech.deepspeech.native_client.${event.head.branchortag}.arm64"
     - "index.project.deepspeech.deepspeech.native_client.${event.head.branchortag}.${event.head.sha}.arm64"
     - "index.project.deepspeech.deepspeech.native_client.arm64.${event.head.sha}"
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.arm64/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.arm64/artifacts/public/home.tar.xz"
   ## multistrap 2.2.0-ubuntu1 is broken in 14.04: https://bugs.launchpad.net/ubuntu/+source/multistrap/+bug/1313787
   system_setup:
     >

--- a/taskcluster/linux-opt-base.tyml
+++ b/taskcluster/linux-opt-base.tyml
@@ -37,7 +37,7 @@ then:
         training: { $eval: as_slugid("test-training_upstream-linux-amd64-py35m-opt") }
       in:
         TENSORFLOW_BUILD_ARTIFACT: ${build.tensorflow}
-        DEEPSPEECH_TEST_MODEL: https://queue.taskcluster.net/v1/task/${training}/artifacts/public/output_graph.pb
+        DEEPSPEECH_TEST_MODEL: https://community-tc.services.mozilla.com/queue/v1/task/${training}/artifacts/public/output_graph.pb
 
     command:
       - "/bin/bash"

--- a/taskcluster/linux-rpi3-cpu-opt.yml
+++ b/taskcluster/linux-rpi3-cpu-opt.yml
@@ -4,7 +4,7 @@ build:
     - "index.project.deepspeech.deepspeech.native_client.${event.head.branchortag}.arm"
     - "index.project.deepspeech.deepspeech.native_client.${event.head.branchortag}.${event.head.sha}.arm"
     - "index.project.deepspeech.deepspeech.native_client.arm.${event.head.sha}"
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.arm/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.arm/artifacts/public/home.tar.xz"
   ## multistrap 2.2.0-ubuntu1 is broken in 14.04: https://bugs.launchpad.net/ubuntu/+source/multistrap/+bug/1313787
   system_setup:
     >

--- a/taskcluster/node-package-cpu.yml
+++ b/taskcluster/node-package-cpu.yml
@@ -17,7 +17,7 @@ build:
   system_config:
     >
       ${swig.patch_nodejs.linux}
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.cpu/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.cpu/artifacts/public/home.tar.xz"
   scripts:
     build: "taskcluster/node-build.sh"
     package: "taskcluster/node-package.sh"

--- a/taskcluster/node-package-gpu.yml
+++ b/taskcluster/node-package-gpu.yml
@@ -14,7 +14,7 @@ build:
   system_config:
     >
       ${swig.patch_nodejs.linux}
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.cpu/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.cpu/artifacts/public/home.tar.xz"
   scripts:
     build: "taskcluster/node-build.sh --cuda"
     package: "taskcluster/node-package.sh"

--- a/taskcluster/tc-tests-utils.sh
+++ b/taskcluster/tc-tests-utils.sh
@@ -1324,10 +1324,10 @@ do_deepspeech_npm_package()
 
   export PATH="$NPM_ROOT/.bin/$PYTHON27:$PATH"
 
-  all_tasks="$(curl -s https://queue.taskcluster.net/v1/task/${TASK_ID} | python -c 'import json; import sys; print(" ".join(json.loads(sys.stdin.read())["dependencies"]));')"
+  all_tasks="$(curl -s https://community-tc.services.mozilla.com/queue/v1/task/${TASK_ID} | python -c 'import json; import sys; print(" ".join(json.loads(sys.stdin.read())["dependencies"]));')"
 
   for dep in ${all_tasks}; do
-    curl -L https://queue.taskcluster.net/v1/task/${dep}/artifacts/public/wrapper.tar.gz | tar -C native_client/javascript -xzvf -
+    curl -L https://community-tc.services.mozilla.com/queue/v1/task/${dep}/artifacts/public/wrapper.tar.gz | tar -C native_client/javascript -xzvf -
   done;
 
   if [ "${rename_to_gpu}" = "--cuda" ]; then
@@ -1351,10 +1351,10 @@ do_deepspeech_java_apk_build()
 
   export ANDROID_HOME=${ANDROID_SDK_HOME}
 
-  all_tasks="$(curl -s https://queue.taskcluster.net/v1/task/${TASK_ID} | python -c 'import json; import sys; print(" ".join(json.loads(sys.stdin.read())["dependencies"]));')"
+  all_tasks="$(curl -s https://community-tc.services.mozilla.com/queue/v1/task/${TASK_ID} | python -c 'import json; import sys; print(" ".join(json.loads(sys.stdin.read())["dependencies"]));')"
 
   for dep in ${all_tasks}; do
-    nc_arch="$(curl -s https://queue.taskcluster.net/v1/task/${dep} | python -c 'import json; import sys; print(json.loads(sys.stdin.read())["extra"]["nc_asset_name"])' | cut -d'.' -f2)"
+    nc_arch="$(curl -s https://community-tc.services.mozilla.com/queue/v1/task/${dep} | python -c 'import json; import sys; print(json.loads(sys.stdin.read())["extra"]["nc_asset_name"])' | cut -d'.' -f2)"
     nc_dir=""
 
     # if a dep is included that has no "nc_asset_name" then it will be empty, just skip
@@ -1374,7 +1374,7 @@ do_deepspeech_java_apk_build()
 
       mkdir native_client/java/libdeepspeech/libs/${nc_dir}
 
-      curl -L https://queue.taskcluster.net/v1/task/${dep}/artifacts/public/native_client.tar.xz | tar -C native_client/java/libdeepspeech/libs/${nc_dir}/ -Jxvf - libdeepspeech.so
+      curl -L https://community-tc.services.mozilla.com/queue/v1/task/${dep}/artifacts/public/native_client.tar.xz | tar -C native_client/java/libdeepspeech/libs/${nc_dir}/ -Jxvf - libdeepspeech.so
     fi;
   done;
 

--- a/taskcluster/test-android-opt-base.tyml
+++ b/taskcluster/test-android-opt-base.tyml
@@ -35,9 +35,9 @@ then:
         android_arm64_build: { $eval: as_slugid("android-arm64-cpu-opt") }
         android_armv7_build: { $eval: as_slugid("android-armv7-cpu-opt") }
       in:
-        DEEPSPEECH_ARTIFACTS_ROOT_ARM64: https://queue.taskcluster.net/v1/task/${android_arm64_build}/artifacts/public
-        DEEPSPEECH_ARTIFACTS_ROOT_ARMV7: https://queue.taskcluster.net/v1/task/${android_armv7_build}/artifacts/public
-        DEEPSPEECH_TEST_MODEL: https://queue.taskcluster.net/v1/task/${training}/artifacts/public/output_graph.pb
+        DEEPSPEECH_ARTIFACTS_ROOT_ARM64: https://community-tc.services.mozilla.com/queue/v1/task/${android_arm64_build}/artifacts/public
+        DEEPSPEECH_ARTIFACTS_ROOT_ARMV7: https://community-tc.services.mozilla.com/queue/v1/task/${android_armv7_build}/artifacts/public
+        DEEPSPEECH_TEST_MODEL: https://community-tc.services.mozilla.com/queue/v1/task/${training}/artifacts/public/output_graph.pb
         EXPECTED_TENSORFLOW_VERSION: "${build.tensorflow_git_desc}"
 
     command:

--- a/taskcluster/test-armbian-opt-base.tyml
+++ b/taskcluster/test-armbian-opt-base.tyml
@@ -35,9 +35,9 @@ then:
         linux_arm64_build: { $eval: as_slugid("linux-arm64-cpu-opt") }
         node_package_cpu: { $eval: as_slugid("node-package-cpu") }
       in:
-        DEEPSPEECH_ARTIFACTS_ROOT: https://queue.taskcluster.net/v1/task/${linux_arm64_build}/artifacts/public
-        DEEPSPEECH_NODEJS: https://queue.taskcluster.net/v1/task/${node_package_cpu}/artifacts/public
-        DEEPSPEECH_TEST_MODEL: https://queue.taskcluster.net/v1/task/${training}/artifacts/public/output_graph.pb
+        DEEPSPEECH_ARTIFACTS_ROOT: https://community-tc.services.mozilla.com/queue/v1/task/${linux_arm64_build}/artifacts/public
+        DEEPSPEECH_NODEJS: https://community-tc.services.mozilla.com/queue/v1/task/${node_package_cpu}/artifacts/public
+        DEEPSPEECH_TEST_MODEL: https://community-tc.services.mozilla.com/queue/v1/task/${training}/artifacts/public/output_graph.pb
         DEEPSPEECH_PROD_MODEL: https://github.com/lissyx/DeepSpeech/releases/download/prod-metadata-constant/output_graph.pb
         DEEPSPEECH_PROD_MODEL_MMAP: https://github.com/lissyx/DeepSpeech/releases/download/prod-metadata-constant/output_graph.pbmm
         PIP_DEFAULT_TIMEOUT: "60"

--- a/taskcluster/test-darwin-opt-base.tyml
+++ b/taskcluster/test-darwin-opt-base.tyml
@@ -39,10 +39,10 @@ then:
         darwin_amd64_tflite: { $eval: as_slugid("darwin-amd64-tflite-opt") }
         node_package_cpu: { $eval: as_slugid("node-package-cpu") }
       in:
-        DEEPSPEECH_ARTIFACTS_ROOT: https://queue.taskcluster.net/v1/task/${darwin_amd64_build}/artifacts/public
-        DEEPSPEECH_ARTIFACTS_TFLITE_ROOT: https://queue.taskcluster.net/v1/task/${darwin_amd64_tflite}/artifacts/public
-        DEEPSPEECH_NODEJS: https://queue.taskcluster.net/v1/task/${node_package_cpu}/artifacts/public
-        DEEPSPEECH_TEST_MODEL: https://queue.taskcluster.net/v1/task/${training}/artifacts/public/output_graph.pb
+        DEEPSPEECH_ARTIFACTS_ROOT: https://community-tc.services.mozilla.com/queue/v1/task/${darwin_amd64_build}/artifacts/public
+        DEEPSPEECH_ARTIFACTS_TFLITE_ROOT: https://community-tc.services.mozilla.com/queue/v1/task/${darwin_amd64_tflite}/artifacts/public
+        DEEPSPEECH_NODEJS: https://community-tc.services.mozilla.com/queue/v1/task/${node_package_cpu}/artifacts/public
+        DEEPSPEECH_TEST_MODEL: https://community-tc.services.mozilla.com/queue/v1/task/${training}/artifacts/public/output_graph.pb
         DEEPSPEECH_PROD_MODEL: https://github.com/lissyx/DeepSpeech/releases/download/prod-metadata-constant/output_graph.pb
         DEEPSPEECH_PROD_MODEL_MMAP: https://github.com/lissyx/DeepSpeech/releases/download/prod-metadata-constant/output_graph.pbmm
         EXPECTED_TENSORFLOW_VERSION: "${build.tensorflow_git_desc}"

--- a/taskcluster/test-linux-opt-base.tyml
+++ b/taskcluster/test-linux-opt-base.tyml
@@ -39,13 +39,13 @@ then:
       in:
         CONVERT_GRAPHDEF_MEMMAPPED: ${build.convert_graphdef}
         BENCHMARK_MODEL_BIN: ${build.benchmark_model_bin}
-        DEEPSPEECH_ARTIFACTS_ROOT: https://queue.taskcluster.net/v1/task/${linux_amd64_build}/artifacts/public
-        DEEPSPEECH_ARTIFACTS_TFLITE_ROOT: https://queue.taskcluster.net/v1/task/${linux_amd64_tflite}/artifacts/public
-        DEEPSPEECH_NODEJS: https://queue.taskcluster.net/v1/task/${node_package_cpu}/artifacts/public
-        DEEPSPEECH_TEST_MODEL: https://queue.taskcluster.net/v1/task/${training}/artifacts/public/output_graph.pb
+        DEEPSPEECH_ARTIFACTS_ROOT: https://community-tc.services.mozilla.com/queue/v1/task/${linux_amd64_build}/artifacts/public
+        DEEPSPEECH_ARTIFACTS_TFLITE_ROOT: https://community-tc.services.mozilla.com/queue/v1/task/${linux_amd64_tflite}/artifacts/public
+        DEEPSPEECH_NODEJS: https://community-tc.services.mozilla.com/queue/v1/task/${node_package_cpu}/artifacts/public
+        DEEPSPEECH_TEST_MODEL: https://community-tc.services.mozilla.com/queue/v1/task/${training}/artifacts/public/output_graph.pb
         DEEPSPEECH_PROD_MODEL: https://github.com/lissyx/DeepSpeech/releases/download/prod-metadata-constant/output_graph.pb
         DEEPSPEECH_PROD_MODEL_MMAP: https://github.com/lissyx/DeepSpeech/releases/download/prod-metadata-constant/output_graph.pbmm
-        DECODER_ARTIFACTS_ROOT: https://queue.taskcluster.net/v1/task/${linux_amd64_ctc}/artifacts/public
+        DECODER_ARTIFACTS_ROOT: https://community-tc.services.mozilla.com/queue/v1/task/${linux_amd64_ctc}/artifacts/public
         PIP_DEFAULT_TIMEOUT: "60"
         EXPECTED_TENSORFLOW_VERSION: "${build.tensorflow_git_desc}"
 

--- a/taskcluster/test-lite_benchmark_model-linux-amd64-opt.yml
+++ b/taskcluster/test-lite_benchmark_model-linux-amd64-opt.yml
@@ -4,7 +4,7 @@ build:
     - "test-training_upstream-linux-amd64-py35m-opt"
   args:
     tests_cmdline: "${system.homedir.linux}/DeepSpeech/ds/taskcluster/tc-lite_benchmark_model-ds-tests.sh"
-  benchmark_model_bin: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.cpu/artifacts/public/lite_benchmark_model"
+  benchmark_model_bin: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.cpu/artifacts/public/lite_benchmark_model"
   metadata:
     name: "DeepSpeech Linux AMD64 CPU TF Lite benchmark_model"
     description: "Testing DeepSpeech TF Lite benchmark_model for Linux/AMD64, CPU only, optimized version"

--- a/taskcluster/test-raspbian-opt-base.tyml
+++ b/taskcluster/test-raspbian-opt-base.tyml
@@ -35,9 +35,9 @@ then:
         linux_rpi3_build: { $eval: as_slugid("linux-rpi3-cpu-opt") }
         node_package_cpu: { $eval: as_slugid("node-package-cpu") }
       in:
-        DEEPSPEECH_ARTIFACTS_ROOT: https://queue.taskcluster.net/v1/task/${linux_rpi3_build}/artifacts/public
-        DEEPSPEECH_NODEJS: https://queue.taskcluster.net/v1/task/${node_package_cpu}/artifacts/public
-        DEEPSPEECH_TEST_MODEL: https://queue.taskcluster.net/v1/task/${training}/artifacts/public/output_graph.pb
+        DEEPSPEECH_ARTIFACTS_ROOT: https://community-tc.services.mozilla.com/queue/v1/task/${linux_rpi3_build}/artifacts/public
+        DEEPSPEECH_NODEJS: https://community-tc.services.mozilla.com/queue/v1/task/${node_package_cpu}/artifacts/public
+        DEEPSPEECH_TEST_MODEL: https://community-tc.services.mozilla.com/queue/v1/task/${training}/artifacts/public/output_graph.pb
         DEEPSPEECH_PROD_MODEL: https://github.com/lissyx/DeepSpeech/releases/download/prod-metadata-constant/output_graph.pb
         DEEPSPEECH_PROD_MODEL_MMAP: https://github.com/lissyx/DeepSpeech/releases/download/prod-metadata-constant/output_graph.pbmm
         PIP_DEFAULT_TIMEOUT: "60"

--- a/taskcluster/test-training_upstream-linux-amd64-py35m-opt.yml
+++ b/taskcluster/test-training_upstream-linux-amd64-py35m-opt.yml
@@ -7,7 +7,7 @@ build:
       apt-get -qq -y install ${python.packages_trusty.apt}
   args:
     tests_cmdline: "${system.homedir.linux}/DeepSpeech/ds/taskcluster/tc-train-tests.sh 3.5.5:m"
-  convert_graphdef: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.cpu/artifacts/public/convert_graphdef_memmapped_format"
+  convert_graphdef: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.cpu/artifacts/public/convert_graphdef_memmapped_format"
   metadata:
     name: "DeepSpeech Linux AMD64 CPU upstream training Py3.5"
     description: "Training a DeepSpeech LDC93S1 model for Linux/AMD64 using upstream TensorFlow Python 3.5, CPU only, optimized version"

--- a/taskcluster/test-win-opt-base.tyml
+++ b/taskcluster/test-win-opt-base.tyml
@@ -41,10 +41,10 @@ then:
         win_amd64_tflite: { $eval: as_slugid("win-amd64-tflite-opt") }
         node_package_cpu: { $eval: as_slugid("node-package-cpu") }
       in:
-        DEEPSPEECH_ARTIFACTS_ROOT: https://queue.taskcluster.net/v1/task/${win_amd64_build}/artifacts/public
-        DEEPSPEECH_ARTIFACTS_TFLITE_ROOT: https://queue.taskcluster.net/v1/task/${win_amd64_tflite}/artifacts/public
-        DEEPSPEECH_NODEJS: https://queue.taskcluster.net/v1/task/${node_package_cpu}/artifacts/public
-        DEEPSPEECH_TEST_MODEL: https://queue.taskcluster.net/v1/task/${training}/artifacts/public/output_graph.pb
+        DEEPSPEECH_ARTIFACTS_ROOT: https://community-tc.services.mozilla.com/queue/v1/task/${win_amd64_build}/artifacts/public
+        DEEPSPEECH_ARTIFACTS_TFLITE_ROOT: https://community-tc.services.mozilla.com/queue/v1/task/${win_amd64_tflite}/artifacts/public
+        DEEPSPEECH_NODEJS: https://community-tc.services.mozilla.com/queue/v1/task/${node_package_cpu}/artifacts/public
+        DEEPSPEECH_TEST_MODEL: https://community-tc.services.mozilla.com/queue/v1/task/${training}/artifacts/public/output_graph.pb
         DEEPSPEECH_PROD_MODEL: https://github.com/lissyx/DeepSpeech/releases/download/prod-metadata-constant/output_graph.pb
         DEEPSPEECH_PROD_MODEL_MMAP: https://github.com/lissyx/DeepSpeech/releases/download/prod-metadata-constant/output_graph.pbmm
         EXPECTED_TENSORFLOW_VERSION: "${build.tensorflow_git_desc}"

--- a/taskcluster/win-amd64-cpu-opt.yml
+++ b/taskcluster/win-amd64-cpu-opt.yml
@@ -6,7 +6,7 @@ build:
     - "index.project.deepspeech.deepspeech.native_client.win.${event.head.sha}"
     - "notify.irc-channel.${notifications.irc}.on-exception"
     - "notify.irc-channel.${notifications.irc}.on-failed"
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.win/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.win/artifacts/public/home.tar.xz"
   scripts:
     build: "taskcluster/win-build.sh"
     package: "taskcluster/win-package.sh"

--- a/taskcluster/win-amd64-gpu-opt.yml
+++ b/taskcluster/win-amd64-gpu-opt.yml
@@ -6,7 +6,7 @@ build:
     - "index.project.deepspeech.deepspeech.native_client.win-cuda.${event.head.sha}"
     - "notify.irc-channel.${notifications.irc}.on-exception"
     - "notify.irc-channel.${notifications.irc}.on-failed"
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.win-cuda/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.win-cuda/artifacts/public/home.tar.xz"
   scripts:
     build: "taskcluster/win-build.sh --cuda"
     package: "taskcluster/win-package.sh"

--- a/taskcluster/win-amd64-tflite-opt.yml
+++ b/taskcluster/win-amd64-tflite-opt.yml
@@ -6,7 +6,7 @@ build:
     - "index.project.deepspeech.deepspeech.native_client.win-tflite.${event.head.sha}"
     - "notify.irc-channel.${notifications.irc}.on-exception"
     - "notify.irc-channel.${notifications.irc}.on-failed"
-  tensorflow: "https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.win/artifacts/public/home.tar.xz"
+  tensorflow: "https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.r1.14.351a98ab6e60c2bf257f05e515a420aba3027d8b.win/artifacts/public/home.tar.xz"
   scripts:
     build: "taskcluster/win-build.sh tflite"
     package: "taskcluster/win-package.sh"

--- a/taskcluster/win-opt-base.tyml
+++ b/taskcluster/win-opt-base.tyml
@@ -42,7 +42,7 @@ payload:
       TC_MSYS_VERSION: 'MSYS_NT-6.3'
       MSYS: 'winsymlinks:nativestrict'
       TENSORFLOW_BUILD_ARTIFACT: ${build.tensorflow}
-      DEEPSPEECH_TEST_MODEL: https://queue.taskcluster.net/v1/task/${training}/artifacts/public/output_graph.pb
+      DEEPSPEECH_TEST_MODEL: https://community-tc.services.mozilla.com/queue/v1/task/${training}/artifacts/public/output_graph.pb
 
   command:
     - >-

--- a/taskcluster/worker.cyml
+++ b/taskcluster/worker.cyml
@@ -1,19 +1,19 @@
 taskcluster:
   schedulerId: taskcluster-github
   docker:
-    provisionerId: aws-provisioner-v1
-    workerType: deepspeech-worker
-    workerTypeKvm: deepspeech-kvm-worker
-    workerTypeWin: deepspeech-win-b
+    provisionerId: proj-deepspeech
+    workerType: ci
+    workerTypeKvm: kvm
+    workerTypeWin: win-b
   dockerrpi3:
-    provisionerId: deepspeech-provisioner
+    provisionerId: proj-deepspeech
     workerType: ds-rpi3
   dockerarm64:
-    provisionerId: deepspeech-provisioner
+    provisionerId: proj-deepspeech
     workerType: ds-lepotato
   generic:
-    provisionerId: deepspeech-provisioner
+    provisionerId: proj-deepspeech
     workerType: ds-macos-light
   script:
-    provisionerId: deepspeech-provisioner
+    provisionerId: proj-deepspeech
     workerType: ds-scriptworker

--- a/util/taskcluster.py
+++ b/util/taskcluster.py
@@ -16,8 +16,8 @@ from pkg_resources import parse_version
 
 
 DEFAULT_SCHEMES = {
-    'deepspeech': 'https://index.taskcluster.net/v1/task/project.deepspeech.deepspeech.native_client.%(branch_name)s.%(arch_string)s/artifacts/public/%(artifact_name)s',
-    'tensorflow': 'https://index.taskcluster.net/v1/task/project.deepspeech.tensorflow.pip.%(branch_name)s.%(arch_string)s/artifacts/public/%(artifact_name)s'
+    'deepspeech': 'https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.deepspeech.native_client.%(branch_name)s.%(arch_string)s/artifacts/public/%(artifact_name)s',
+    'tensorflow': 'https://community-tc.services.mozilla.com/index/v1/task/project.deepspeech.tensorflow.pip.%(branch_name)s.%(arch_string)s/artifacts/public/%(artifact_name)s'
 }
 
 TASKCLUSTER_SCHEME = os.getenv('TASKCLUSTER_SCHEME', DEFAULT_SCHEMES['deepspeech'])


### PR DESCRIPTION
This is a first pass at the things that need to change to move deepspeech's CI from taskcluster.net to the [new community-tc deployment](https://community-tc.services.mozilla.com/)

- replaces instances of `$service.taskcluster.net` with `community-tc.services.mozilla.com/$service` (route based urls instead of subdomains)
- replaces workerTypes and provisionerIds with the new ones defined for the project [here](https://github.com/mozilla/community-tc-config/pull/51/)

Do you see any glaring holes here? My plan is to mirror this conversion for https://github.com/mozilla/tensorflow.

Bug [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1574659)