### PR TITLE
Remove first party code from common.a

### DIFF
--- a/native_client/ctcdecode/build_common.py
+++ b/native_client/ctcdecode/build_common.py
@@ -32,8 +32,6 @@ COMMON_FILES = [
         'unittest.cc'))
 ]
 
-COMMON_FILES += glob.glob('*.cpp')
-
 def build_common(out_name='common.a', build_dir='temp_build/temp_build', debug=False, num_parallel=1):
     compiler = os.environ.get('CXX', 'g++')
     ar = os.environ.get('AR', 'ar')

--- a/native_client/ctcdecode/setup.py
+++ b/native_client/ctcdecode/setup.py
@@ -49,14 +49,18 @@ if not os.path.exists(common_build):
     if not os.path.exists(build_dir):
         os.makedirs(build_dir)
 
-    build_common(out_name='common.a',
+    build_common(out_name=common_build,
                  build_dir=build_dir,
                  num_parallel=known_args.num_processes,
                  debug=debug)
 
 decoder_module = Extension(
     name='ds_ctcdecoder._swigwrapper',
-    sources=['swigwrapper.i'],
+    sources=['swigwrapper.i',
+             'ctc_beam_search_decoder.cpp',
+             'scorer.cpp',
+             'path_trie.cpp',
+             'decoder_utils.cpp'],
     swig_opts=['-c++', '-extranative'],
     language='c++',
     include_dirs=INCLUDES + [numpy_include],


### PR DESCRIPTION
These files are much more likely to be edited by us, and having them in common.a slows downs the development hugely because we have to build all the third party libraries every time, even though they never change. This is a good compromise between fast automation builds and good development speed.