### PR TITLE
updated readme with correct transcribing command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ To install and use deepspeech all you have to do is:
    tar xvf audio-0.5.1.tar.gz
 
    # Transcribe an audio file
-   deepspeech --model deepspeech-0.5.1-models/output_graph.pbmm --lm deepspeech-0.5.1-models/lm.binary --trie deepspeech-0.5.1-models/trie --audio audio/2830-3980-0043.wav
+   deepspeech --model deepspeech-0.5.1-models/output_graph.pbmm --lm deepspeech-0.5.1-models/lm.binary --trie deepspeech-0.5.1-models/trie --alphabet deepspeech-0.5.1-models/alphabet.txt --audio audio/2830-3980-0043.wav
 
 A pre-trained English model is available for use and can be downloaded using `the instructions below <USING.rst#using-a-pre-trained-model>`_. Currently, only 16-bit, 16 kHz, mono-channel WAVE audio files are supported in the Python client. A package with some example audio files is available for download in our `release notes <https://github.com/mozilla/DeepSpeech/releases/latest>`_.
 


### PR DESCRIPTION
Transcribing command for non-gpu case when run directly gives an error: "**deepspeech: error: the following arguments are required: --alphabet**". Updated it with the correct command:

<img width="1440" alt="error" src="https://user-images.githubusercontent.com/10601664/69664790-12dcc180-10af-11ea-8c87-f581e45dc1a8.png">
