### PR TITLE
Warn about master docs applying to master only

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,8 @@ Project DeepSpeech
 
 DeepSpeech is an open source Speech-To-Text engine, using a model trained by machine learning techniques based on `Baidu's Deep Speech research paper <https://arxiv.org/abs/1412.5567>`_. Project DeepSpeech uses Google's `TensorFlow <https://www.tensorflow.org/>`_ to make the implementation easier.
 
+**NOTE:** This documentation applies to the **master branch** of DeepSpeech only. If you're using a stable release, you must use the documentation for the corresponding version by using GitHub's branch switcher button above.
+
 To install and use deepspeech all you have to do is:
 
 .. code-block:: bash


### PR DESCRIPTION
This will need to be changed/removed when we do a stable release, and then added again, which is a pain, but given the amount of confusion we've seen due to master docs diverging from stable, I think it's worth it. We could also wait until after 0.6.0 to merge this so we don't have to do this dance so soon.