### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ To install and use deepspeech all you have to do is:
    tar xvf audio-0.6.0.tar.gz
 
    # Transcribe an audio file
-   deepspeech --model deepspeech-0.6.0-models/output_graph.pbmm --lm deepspeech-0.6.0-models/lm.binary --trie deepspeech-0.6.0-models/trie --audio audio/2830-3980-0043.wav
+   deepspeech --model deepspeech-0.6.0-models/output_graph.pbmm --alphabet deepspeech-0.6.0-models/alphabet.txt --lm deepspeech-0.6.0-models/lm.binary --trie deepspeech-0.6.0-models/trie --audio audio/2830-3980-0043.wav
 
 A pre-trained English model is available for use and can be downloaded using `the instructions below <USING.rst#using-a-pre-trained-model>`_. Currently, only 16-bit, 16 kHz, mono-channel WAVE audio files are supported in the Python client. A package with some example audio files is available for download in our `release notes <https://github.com/mozilla/DeepSpeech/releases/latest>`_.
 
@@ -52,7 +52,7 @@ Quicker inference can be performed using a supported NVIDIA GPU on Linux. See th
    pip3 install deepspeech-gpu
 
    # Transcribe an audio file.
-   deepspeech --model deepspeech-0.6.0-models/output_graph.pbmm --lm deepspeech-0.6.0-models/lm.binary --trie deepspeech-0.6.0-models/trie --audio audio/2830-3980-0043.wav
+   deepspeech --model deepspeech-0.6.0-models/output_graph.pbmm --alphabet deepspeech-0.6.0-models/alphabet.txt --lm deepspeech-0.6.0-models/lm.binary --trie deepspeech-0.6.0-models/trie --audio audio/2830-3980-0043.wav
 
 Please ensure you have the required `CUDA dependencies <USING.rst#cuda-dependency>`_.
 


### PR DESCRIPTION
Corrected the instructions to transcribe the audio file using deepspeech's default arguments. `--alphabet deepspeech-0.6.0-models/alphabet.txt` was missing in argument passing.