### PR TITLE
Update to specify which package libpthread is in

### DIFF
--- a/USING.rst
+++ b/USING.rst
@@ -12,10 +12,10 @@ Inference using a DeepSpeech pre-trained model can be done with a client/languag
 Running ``deepspeech`` might, see below, require some runtime dependencies to be already installed on your system:
 
 
-* sox - The Python and Node.JS clients use SoX to resample files to 16kHz.
-* libgomp1 - libsox (statically linked into the clients) depends on OpenMP. Some people have had to install this manually.
-* libstdc++ - Standard C++ Library implementation. Some people have had to install this manually.
-* libpthread - On Linux, some people have had to install libpthread manually.
+* ``sox`` - The Python and Node.JS clients use SoX to resample files to 16kHz.
+* ``libgomp1`` - libsox (statically linked into the clients) depends on OpenMP. Some people have had to install this manually.
+* ``libstdc++`` - Standard C++ Library implementation. Some people have had to install this manually.
+* ``libpthread`` - On Linux, some people have had to install libpthread manually. On Ubuntu, ``libpthread`` is part of the `` ``libpthread-stubs0-dev`` package.  
 
 Please refer to your system's documentation on how to install these dependencies.
 


### PR DESCRIPTION
libpthread on Ubuntu (and presumably any other Debian or Debian derivatives) is in the libpthread-stubs0-dev package, it took me a bit of digging to find it. Best, Kathy