### PR TITLE
online mix noise audio data in training step

### DIFF
--- a/util/decoded_augmentation.py
+++ b/util/decoded_augmentation.py
@@ -1,0 +1,67 @@
+import tensorflow as tf
+import tensorflow.compat.v1 as tfv1
+from tensorflow.python.ops import gen_audio_ops as contrib_audio
+import os
+
+
+def augment_noise(audio,
+                  walk_dirs,
+                  change_audio_db_max=0,
+                  change_audio_db_min=-10,
+                  change_noise_db_max=-25,
+                  change_noise_db_min=-50
+                  ):
+    noise_filenames = []
+    for d in walk_dirs:
+        for dirpath, _, filenames in os.walk(d):
+            for filename in filenames:
+                if filename.endswith('.wav'):
+                    noise_filenames.append(os.path.join(dirpath, filename))
+    print('Collect {} noise filenames for augmentation'.format(len(noise_filenames)))
+    noise_filenames = tf.convert_to_tensor(noise_filenames, dtype=tf.string)
+
+    rand_int = tfv1.random_uniform(
+        [], dtype=tf.int32, minval=0, maxval=tf.shape(noise_filenames)[0])
+    noise_filename = noise_filenames[rand_int]
+    noise_samples = tf.io.read_file(noise_filename)
+    noise_decoded = contrib_audio.decode_wav(noise_samples, desired_channels=1)
+    noise_audio = noise_decoded.audio
+
+    decoded_audio_len = tf.shape(audio)[0]
+    noise_decoded_audio_len = tf.shape(noise_audio)[0]
+
+    multiply = tf.math.floordiv(decoded_audio_len, noise_decoded_audio_len) + 1
+    noise_audio = tf.tile(noise_audio, [multiply, 1])
+
+    # now noise_decoded_len must > decoded_len
+    noise_decoded_audio_len = tf.shape(noise_audio)[0]
+
+    mix_decoded_start_end_points = tfv1.random_uniform(
+        [2], minval=0, maxval=decoded_audio_len-1, dtype=tf.int32)
+    mix_decoded_start_point = tf.math.reduce_min(mix_decoded_start_end_points)
+    mix_decoded_end_point = tf.math.reduce_max(
+        mix_decoded_start_end_points) + 1
+    mix_decoded_width = mix_decoded_end_point - mix_decoded_start_point
+
+    left_zeros = tf.zeros(shape=[mix_decoded_start_point, 1])
+
+    mix_noise_decoded_start_point = tfv1.random_uniform(
+        [], minval=0, maxval=noise_decoded_audio_len - mix_decoded_width, dtype=tf.int32)
+    mix_noise_decoded_end_point = mix_noise_decoded_start_point + mix_decoded_width
+    extract_noise_decoded = noise_audio[mix_noise_decoded_start_point:mix_noise_decoded_end_point, :]
+
+    right_zeros = tf.zeros(
+        shape=[decoded_audio_len - mix_decoded_end_point, 1])
+
+    mixed_noise = tf.concat(
+        [left_zeros, extract_noise_decoded, right_zeros], axis=0)
+
+    choosen_audio_db = tfv1.random_uniform(
+        [], minval=change_audio_db_min, maxval=change_audio_db_max)
+    audio_ratio = tf.math.exp(choosen_audio_db / 10)
+
+    choosen_noise_db = tfv1.random_uniform(
+        [], minval=change_noise_db_min, maxval=change_noise_db_max)
+    noise_ratio = tf.math.exp(choosen_noise_db / 10)
+
+    return tf.multiply(audio, audio_ratio) + tf.multiply(mixed_noise, noise_ratio)

--- a/util/decoded_augmentation.py
+++ b/util/decoded_augmentation.py
@@ -8,9 +8,9 @@ def augment_noise(audio,
                   walk_dirs,
                   change_audio_db_max=0,
                   change_audio_db_min=-10,
-                  change_noise_db_max=-25,
-                  change_noise_db_min=-50
-                  ):
+                  change_noise_db_max=-15,
+                  change_noise_db_min=-25):
+    assert isinstance(walk_dirs, list)
     noise_filenames = []
     for d in walk_dirs:
         for dirpath, _, filenames in os.walk(d):
@@ -31,10 +31,10 @@ def augment_noise(audio,
     noise_decoded_audio_len = tf.shape(noise_audio)[0]
 
     multiply = tf.math.floordiv(decoded_audio_len, noise_decoded_audio_len) + 1
-    noise_audio = tf.tile(noise_audio, [multiply, 1])
+    noise_audio_tile = tf.tile(noise_audio, [multiply, 1])
 
     # now noise_decoded_len must > decoded_len
-    noise_decoded_audio_len = tf.shape(noise_audio)[0]
+    noise_decoded_audio_len = tf.shape(noise_audio_tile)[0]
 
     mix_decoded_start_end_points = tfv1.random_uniform(
         [2], minval=0, maxval=decoded_audio_len-1, dtype=tf.int32)
@@ -48,7 +48,7 @@ def augment_noise(audio,
     mix_noise_decoded_start_point = tfv1.random_uniform(
         [], minval=0, maxval=noise_decoded_audio_len - mix_decoded_width, dtype=tf.int32)
     mix_noise_decoded_end_point = mix_noise_decoded_start_point + mix_decoded_width
-    extract_noise_decoded = noise_audio[mix_noise_decoded_start_point:mix_noise_decoded_end_point, :]
+    extract_noise_decoded = noise_audio_tile[mix_noise_decoded_start_point:mix_noise_decoded_end_point, :]
 
     right_zeros = tf.zeros(
         shape=[decoded_audio_len - mix_decoded_end_point, 1])
@@ -58,10 +58,11 @@ def augment_noise(audio,
 
     choosen_audio_db = tfv1.random_uniform(
         [], minval=change_audio_db_min, maxval=change_audio_db_max)
-    audio_ratio = tf.math.exp(choosen_audio_db / 10)
+    audio_ratio = tf.math.pow(10.0, choosen_audio_db / 10)
 
     choosen_noise_db = tfv1.random_uniform(
         [], minval=change_noise_db_min, maxval=change_noise_db_max)
-    noise_ratio = tf.math.exp(choosen_noise_db / 10)
-
+    # choosen_noise_db = tf.random.normal(
+    #     [], mean=change_noise_db_max, stddev=change_noise_db_min)
+    noise_ratio = tf.math.pow(10.0, choosen_noise_db / 10)
     return tf.multiply(audio, audio_ratio) + tf.multiply(mixed_noise, noise_ratio)

--- a/util/feeding.py
+++ b/util/feeding.py
@@ -71,25 +71,25 @@ def audiofile_to_features(wav_filename, train_phase=False):
     audio = decoded.audio
 
     # augment audio
-    if train_phase and FLAGS.decoded_aug_mix_noise_walk_dirs:
+    if train_phase and FLAGS.audio_aug_mix_noise_walk_dirs:
         # because we have to determine the shuffle size, so we could not use generator
         noise_filenames = tf.convert_to_tensor(
-            list(collect_noise_filenames(FLAGS.decoded_aug_mix_noise_walk_dirs.split(','))),
+            list(collect_noise_filenames(FLAGS.audio_aug_mix_noise_walk_dirs.split(','))),
             dtype=tf.string)
         print(">>> Collect {} noise files for mixing audio".format(noise_filenames.shape[0]))
         noise_dataset = (tf.data.Dataset.from_tensor_slices(noise_filenames)
                          .map(noise_file_to_audio, num_parallel_calls=tf.data.experimental.AUTOTUNE)
                          .shuffle(noise_filenames.shape[0])
-                         .cache(FLAGS.decoded_aug_mix_noise_cache)
+                         .cache(FLAGS.audio_aug_mix_noise_cache)
                          .repeat())
         iterator = tf.compat.v1.data.make_one_shot_iterator(noise_dataset)
         audio = augment_noise(
             audio,
             iterator.get_next(),
-            change_audio_db_max=FLAGS.decoded_aug_mix_noise_max_audio_db,
-            change_audio_db_min=FLAGS.decoded_aug_mix_noise_min_audio_db,
-            change_noise_db_max=FLAGS.decoded_aug_mix_noise_max_noise_db,
-            change_noise_db_min=FLAGS.decoded_aug_mix_noise_min_noise_db,
+            change_audio_db_max=FLAGS.audio_aug_mix_noise_max_audio_db,
+            change_audio_db_min=FLAGS.audio_aug_mix_noise_min_audio_db,
+            change_noise_db_max=FLAGS.audio_aug_mix_noise_max_noise_db,
+            change_noise_db_min=FLAGS.audio_aug_mix_noise_min_noise_db,
         )
 
 

--- a/util/flags.py
+++ b/util/flags.py
@@ -24,6 +24,12 @@ def create_flags():
     # Data Augmentation
     # ================
 
+    f.DEFINE_string('decoded_aug_mix_noise_walk_dirs', '', 'walk through wav dir, then mix noise wav into decoded audio')
+    f.DEFINE_float('decoded_aug_mix_noise_max_noise_db', -25, 'limit noise max volume')
+    f.DEFINE_float('decoded_aug_mix_noise_min_noise_db', -50, 'limit noise min volume')
+    f.DEFINE_float('decoded_aug_mix_noise_max_audio_db', 0, 'limit noise max volume')
+    f.DEFINE_float('decoded_aug_mix_noise_min_audio_db', -10, 'limit noise min volume')
+
     f.DEFINE_float('data_aug_features_additive', 0, 'std of the Gaussian additive noise')
     f.DEFINE_float('data_aug_features_multiplicative', 0, 'std of normal distribution around 1 for multiplicative noise')
 
@@ -41,7 +47,6 @@ def create_flags():
     f.DEFINE_float('augmentation_pitch_and_tempo_scaling_min_pitch', 0.95, 'min value of pitch scaling')
     f.DEFINE_float('augmentation_pitch_and_tempo_scaling_max_pitch', 1.2, 'max value of pitch scaling')
     f.DEFINE_float('augmentation_pitch_and_tempo_scaling_max_tempo', 1.2, 'max vlaue of tempo scaling')
-
 
     # Global Constants
     # ================

--- a/util/flags.py
+++ b/util/flags.py
@@ -25,10 +25,11 @@ def create_flags():
     # ================
 
     f.DEFINE_string('decoded_aug_mix_noise_walk_dirs', '', 'walk through wav dir, then mix noise wav into decoded audio')
-    f.DEFINE_float('decoded_aug_mix_noise_max_noise_db', -25, 'limit noise max volume')
-    f.DEFINE_float('decoded_aug_mix_noise_min_noise_db', -50, 'limit noise min volume')
-    f.DEFINE_float('decoded_aug_mix_noise_max_audio_db', 0, 'limit noise max volume')
-    f.DEFINE_float('decoded_aug_mix_noise_min_audio_db', -10, 'limit noise min volume')
+    f.DEFINE_string('decoded_aug_mix_noise_cache', '', 'must cache noise audio data, or it will read audio file every training step')
+    f.DEFINE_float('decoded_aug_mix_noise_max_noise_db', -25, 'to limit noise max volume')
+    f.DEFINE_float('decoded_aug_mix_noise_min_noise_db', -50, 'to limit noise min volume')
+    f.DEFINE_float('decoded_aug_mix_noise_max_audio_db', 0, 'to limit audio max volume')
+    f.DEFINE_float('decoded_aug_mix_noise_min_audio_db', -10, 'to limit audio min volume')
 
     f.DEFINE_float('data_aug_features_additive', 0, 'std of the Gaussian additive noise')
     f.DEFINE_float('data_aug_features_multiplicative', 0, 'std of normal distribution around 1 for multiplicative noise')

--- a/util/flags.py
+++ b/util/flags.py
@@ -24,12 +24,12 @@ def create_flags():
     # Data Augmentation
     # ================
 
-    f.DEFINE_string('decoded_aug_mix_noise_walk_dirs', '', 'walk through wav dir, then mix noise wav into decoded audio')
-    f.DEFINE_string('decoded_aug_mix_noise_cache', '', 'must cache noise audio data, or it will read audio file every training step')
-    f.DEFINE_float('decoded_aug_mix_noise_max_noise_db', -25, 'to limit noise max volume')
-    f.DEFINE_float('decoded_aug_mix_noise_min_noise_db', -50, 'to limit noise min volume')
-    f.DEFINE_float('decoded_aug_mix_noise_max_audio_db', 0, 'to limit audio max volume')
-    f.DEFINE_float('decoded_aug_mix_noise_min_audio_db', -10, 'to limit audio min volume')
+    f.DEFINE_string('audio_aug_mix_noise_walk_dirs', '', 'walk through wav dir, then mix noise wav into decoded audio')
+    f.DEFINE_string('audio_aug_mix_noise_cache', '', 'must cache noise audio data, or it will read audio file every training step')
+    f.DEFINE_float('audio_aug_mix_noise_max_noise_db', -25, 'to limit noise max volume')
+    f.DEFINE_float('audio_aug_mix_noise_min_noise_db', -50, 'to limit noise min volume')
+    f.DEFINE_float('audio_aug_mix_noise_max_audio_db', 0, 'to limit audio max volume')
+    f.DEFINE_float('audio_aug_mix_noise_min_audio_db', -10, 'to limit audio min volume')
 
     f.DEFINE_float('data_aug_features_additive', 0, 'std of the Gaussian additive noise')
     f.DEFINE_float('data_aug_features_multiplicative', 0, 'std of normal distribution around 1 for multiplicative noise')


### PR DESCRIPTION
Mixing noisy data into training file before runtime could cause data monotonicity, but mixing noisy data in runtime could cause very bad performance, if we read each noise audio to augment each training row. (Ex: for HDD disk, the duration of mixing one audio is almost 100 times slower than freq_time_mask does).

To reduce online mixing time, I use another tf.Dataset to cache noise audio array, then mix them to training data.

usage:
```
python -u DeepSpeech.py --noshow_progressbar \
  --train_files data/ldc93s1/ldc93s1.csv \
  --test_files data/ldc93s1/ldc93s1.csv \
  --train_batch_size 1 \
  --test_batch_size 1 \
  --n_hidden 200 \
  --epochs 200 \
  --checkpoint_dir <checkpoint_dir> \
  --audio_aug_mix_noise_walk_dirs <directory1-contains-wav-files>,<directory2-contains-wav-files>
```
- Just specify the noise file directory, the process will automatically walk through the whole directory recursively, and collect .wav files (but it doesn't checkout the sample rate).
- This program assume every volume of noise audio have been maximized, to save the calculation time of each speech/noise volume balance, it just simply divide speech audio with value between `0~-10 db`, and divide noise audio with value between `-25~-50 db`
- The augment time can be as fast as freq_time_mask
- `--audio_aug_mix_noise_walk_dirs` can set multi dirs with comma separated.

To manually adjust volume loudness suppression:
```
python -u DeepSpeech.py \
...
--audio_aug_mix_noise_max_noise_db -25 \
--audio_aug_mix_noise_min_noise_db -50 \
--audio_aug_mix_noise_max_audio_db 0 \
--audio_aug_mix_noise_min_audio_db -10 \
...
```
- If your noise files are pure non-speaker noise, my experience paramters is `--audio_aug_mix_noise_max_noise_db -15`, `--audio_aug_mix_noise_min_noise_db -25`
- If your noise files are from speakers, like cocktail party, my experience paramters is `--audio_aug_mix_noise_max_noise_db -30`, `--audio_aug_mix_noise_min_noise_db -50`, otherwise, the voice can have a chance to cover the main speaker's volume.
- If you want to cache audio array into local disk, set `--audio_aug_mix_noise_cache <your cache path>`, otherwise cache in memory.