### PR TITLE
added an argument to choose the final export model name

### DIFF
--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -812,7 +812,7 @@ def export():
     checkpoint = tf.train.get_checkpoint_state(FLAGS.checkpoint_dir)
     checkpoint_path = checkpoint.model_checkpoint_path
 
-    output_filename = 'output_graph.pb'
+    output_filename = FLAGS.export_name +'.pb'
     if FLAGS.remove_export:
         if os.path.isdir(FLAGS.export_dir):
             log_info('Removing old export')

--- a/util/flags.py
+++ b/util/flags.py
@@ -110,6 +110,7 @@ def create_flags():
     f.DEFINE_integer('n_steps', 16, 'how many timesteps to process at once by the export graph, higher values mean more latency')
     f.DEFINE_string('export_language', '', 'language the model was trained on e.g. "en" or "English". Gets embedded into exported model.')
     f.DEFINE_boolean('export_zip', False, 'export a TFLite model and package with LM and info.json')
+    f.DEFINE_string('export_name','output_graph', 'name for the export model')
 
     # Reporting
 


### PR DESCRIPTION
When training models i felt like an argument was missing to choose the name of the export model when done training.
use as:
```
python -u DeepSpeech.py --noshow_progressbar \
   --train_files data/ldc93s1/ldc93s1.csv \
   --test_files data/ldc93s1/ldc93s1.csv \
   --train_batch_size 1 \
   --test_batch_size 1 \
   --n_hidden 200 \
   --epochs 200 \
   --export_name name_of_model \
```
if no arg is given it will just use output_graph as name