### PR TITLE
Fix a memory leak in tfmodelstate.cc

### DIFF
--- a/native_client/tfmodelstate.cc
+++ b/native_client/tfmodelstate.cc
@@ -19,6 +19,7 @@ TFModelState::~TFModelState()
     if (!status.ok()) {
       std::cerr << "Error closing TensorFlow session: " << status << std::endl;
     }
+    delete session_;
   }
   delete mmap_env_;
 }


### PR DESCRIPTION
`tensorflow::Session* session_` defined in tfmodelstate.h is deleted nowhere, so when I create and delete an instance of TFModelState repeatedly, I found a memory leak.