### PR TITLE
Expose multiple transcriptions

### DIFF
--- a/doc/TRAINING.rst
+++ b/doc/TRAINING.rst
@@ -48,6 +48,12 @@ Install the required dependencies using ``pip3``\ :
    cd DeepSpeech
    pip3 install -r requirements.txt
 
+The ``webrtcvad`` Python package might require you to ensure you have proper tooling to build Python modules:
+
+.. code-block:: bash
+
+   sudo apt-get install python3-dev
+
 You'll also need to install the ``ds_ctcdecoder`` Python package. ``ds_ctcdecoder`` is required for decoding the outputs of the ``deepspeech`` acoustic model into text. You can use ``util/taskcluster.py`` with the ``--decoder`` flag to get a URL to a binary of the decoder package appropriate for your platform and Python version:
 
 .. code-block:: bash

--- a/native_client/client.cc
+++ b/native_client/client.cc
@@ -46,7 +46,7 @@ struct meta_word {
 
 char* metadataToString(Metadata* metadata);
 std::vector<meta_word> WordsFromMetadata(Metadata* metadata);
-char* JSONOutput(Metadata* metadata);
+char* JSONOutput(Result* result);
 
 ds_result
 LocalDsSTT(ModelState* aCtx, const short* aBuffer, size_t aBufferSize,
@@ -57,13 +57,13 @@ LocalDsSTT(ModelState* aCtx, const short* aBuffer, size_t aBufferSize,
   clock_t ds_start_time = clock();
 
   if (extended_output) {
-    Metadata *metadata = DS_SpeechToTextWithMetadata(aCtx, aBuffer, aBufferSize);
-    res.string = metadataToString(metadata);
-    DS_FreeMetadata(metadata);
+    Result *result = DS_SpeechToTextWithMetadata(aCtx, aBuffer, aBufferSize, 1);
+    res.string = metadataToString(&result->transcriptions[0]);
+    DS_FreeResult(result);
   } else if (json_output) {
-    Metadata *metadata = DS_SpeechToTextWithMetadata(aCtx, aBuffer, aBufferSize);
-    res.string = JSONOutput(metadata);
-    DS_FreeMetadata(metadata);
+    Result *result = DS_SpeechToTextWithMetadata(aCtx, aBuffer, aBufferSize, 3);
+    res.string = JSONOutput(result);
+    DS_FreeResult(result);
   } else if (stream_size > 0) {
     StreamingState* ctx;
     int status = DS_CreateStream(aCtx, &ctx);
@@ -338,23 +338,34 @@ WordsFromMetadata(Metadata* metadata)
 }
 
 char* 
-JSONOutput(Metadata* metadata)
+JSONOutput(Result* result)
 {
-  std::vector<meta_word> words = WordsFromMetadata(metadata);
-
   std::ostringstream out_string;
-  out_string << R"({"metadata":{"confidence":)" << metadata->confidence << R"(},"words":[)";
+  out_string << "[\n";
 
-  for (int i = 0; i < words.size(); i++) {
-    meta_word w = words[i];
-    out_string << R"({"word":")" << w.word << R"(","time":)" << w.start_time << R"(,"duration":)" << w.duration << "}";
+  for (int j=0; j < result->num_transcriptions; ++j) {
+    Metadata *metadata = &result->transcriptions[j];
+    std::vector<meta_word> words = WordsFromMetadata(metadata);
 
-    if (i < words.size() - 1) {
-      out_string << ",";
+    out_string << R"({"metadata":{"confidence":)" << metadata->confidence << R"(},"words":[)";
+
+    for (int i = 0; i < words.size(); i++) {
+      meta_word w = words[i];
+      out_string << R"({"word":")" << w.word << R"(","time":)" << w.start_time << R"(,"duration":)" << w.duration << "}";
+
+      if (i < words.size() - 1) {
+        out_string << ",";
+      }
+    }
+
+    out_string << "]}";
+
+    if (j < result->num_transcriptions - 1) {
+        out_string << ",\n";
     }
   }
   
-  out_string << "]}\n";
+  out_string << "\n]\n";
 
   return strdup(out_string.str().c_str());
 }

--- a/native_client/ctcdecode/ctc_beam_search_decoder.h
+++ b/native_client/ctcdecode/ctc_beam_search_decoder.h
@@ -61,11 +61,14 @@ public:
 
   /* Get transcription from current decoder state
    *
+   * Parameters:
+   *     top_paths: The number of results to return.
+   * 
    * Return:
    *     A vector where each element is a pair of score and decoding result,
    *     in descending order.
   */
-  std::vector<Output> decode() const;
+  std::vector<Output> decode(size_t top_paths) const;
 };
 
 
@@ -77,6 +80,7 @@ public:
  *     class_dim: Alphabet length (plus 1 for space character).
  *     alphabet: The alphabet.
  *     beam_size: The width of beam search.
+ *     top_paths: The number of results to return.
  *     cutoff_prob: Cutoff probability for pruning.
  *     cutoff_top_n: Cutoff number for pruning.
  *     ext_scorer: External scorer to evaluate a prefix, which consists of
@@ -93,6 +97,7 @@ std::vector<Output> ctc_beam_search_decoder(
     int class_dim,
     const Alphabet &alphabet,
     size_t beam_size,
+    size_t top_paths,
     double cutoff_prob,
     size_t cutoff_top_n,
     Scorer *ext_scorer);
@@ -103,6 +108,7 @@ std::vector<Output> ctc_beam_search_decoder(
  *                by ctc_beam_search_decoder().
  *     alphabet: The alphabet.
  *     beam_size: The width of beam search.
+ *     top_paths: The number of results to return.
  *     num_processes: Number of threads for beam search.
  *     cutoff_prob: Cutoff probability for pruning.
  *     cutoff_top_n: Cutoff number for pruning.
@@ -123,6 +129,7 @@ ctc_beam_search_decoder_batch(
     int seq_lengths_size,
     const Alphabet &alphabet,
     size_t beam_size,
+    size_t top_paths,
     size_t num_processes,
     double cutoff_prob,
     size_t cutoff_top_n,

--- a/native_client/deepspeech.cc
+++ b/native_client/deepspeech.cc
@@ -80,7 +80,7 @@ struct StreamingState {
   char* intermediateDecode();
   void finalizeStream();
   char* finishStream();
-  Metadata* finishStreamWithMetadata();
+  Result* finishStreamWithMetadata(unsigned int numResults);
 
   void processAudioWindow(const vector<float>& buf);
   void processMfccWindow(const vector<float>& buf);
@@ -143,11 +143,26 @@ StreamingState::finishStream()
   return model_->decode(decoder_state_);
 }
 
-Metadata*
-StreamingState::finishStreamWithMetadata()
+Result*
+StreamingState::finishStreamWithMetadata(unsigned int numResults)
 {
   finalizeStream();
-  return model_->decode_metadata(decoder_state_);
+
+  vector<Metadata*> metadata = model_->decode_metadata(decoder_state_, numResults);
+
+  std::unique_ptr<Result> result(new Result());
+  result->num_transcriptions = metadata.size();
+
+  std::unique_ptr<Metadata[]> items(new Metadata[result->num_transcriptions]);
+
+  for (int i = 0; i < result->num_transcriptions; ++i) {
+      std::unique_ptr<Metadata> pointer(new Metadata(*metadata[i]));
+      items[i] = *pointer.release();
+  }
+
+  result->transcriptions = items.release();
+
+  return result.release();
 }
 
 void
@@ -376,12 +391,13 @@ DS_FinishStream(StreamingState* aSctx)
   return str;
 }
 
-Metadata*
-DS_FinishStreamWithMetadata(StreamingState* aSctx)
+Result*
+DS_FinishStreamWithMetadata(StreamingState* aSctx, 
+                            unsigned int numResults)
 {
-  Metadata* metadata = aSctx->finishStreamWithMetadata();
+  Result* result = aSctx->finishStreamWithMetadata(numResults);
   DS_FreeStream(aSctx);
-  return metadata;
+  return result;
 }
 
 StreamingState*
@@ -407,13 +423,14 @@ DS_SpeechToText(ModelState* aCtx,
   return DS_FinishStream(ctx);
 }
 
-Metadata*
+Result*
 DS_SpeechToTextWithMetadata(ModelState* aCtx,
                             const short* aBuffer,
-                            unsigned int aBufferSize)
+                            unsigned int aBufferSize,
+                            unsigned int numResults)
 {
   StreamingState* ctx = CreateStreamAndFeedAudioContent(aCtx, aBuffer, aBufferSize);
-  return DS_FinishStreamWithMetadata(ctx);
+  return DS_FinishStreamWithMetadata(ctx, numResults);
 }
 
 void
@@ -431,6 +448,25 @@ DS_FreeMetadata(Metadata* m)
     }
     delete[] m->items;
     delete m;
+  }
+}
+
+void
+DS_FreeResult(Result* r)
+{
+  if (r) {
+    for (int i = 0; i < r->num_transcriptions; ++i) {
+        Metadata* m = &r->transcriptions[i];
+
+        for (int j = 0; j < m->num_items; ++j) {
+          free(m->items[j].character);
+        }
+
+      delete[] m->items;
+    }
+
+    delete[] r->transcriptions;
+    delete r;
   }
 }
 

--- a/native_client/deepspeech.h
+++ b/native_client/deepspeech.h
@@ -48,6 +48,16 @@ typedef struct Metadata {
   double confidence;
 } Metadata;
 
+/**
+ * @brief Stores Metadata structs for each alternative transcription
+ */
+typedef struct Result {
+  /** List of transcriptions */
+  Metadata* transcriptions;
+  /** Size of the list of transcriptions */
+  int num_transcriptions;
+} Result;
+
 enum DeepSpeech_Error_Codes
 {
     // OK
@@ -155,9 +165,10 @@ char* DS_SpeechToText(ModelState* aCtx,
  *         The user is responsible for freeing Metadata by calling {@link DS_FreeMetadata()}. Returns NULL on error.
  */
 DEEPSPEECH_EXPORT
-Metadata* DS_SpeechToTextWithMetadata(ModelState* aCtx,
+Result* DS_SpeechToTextWithMetadata(ModelState* aCtx,
                                       const short* aBuffer,
-                                      unsigned int aBufferSize);
+                                      unsigned int aBufferSize,
+                                      unsigned int numResults);
 
 /**
  * @brief Create a new streaming inference state. The streaming state returned
@@ -224,7 +235,8 @@ char* DS_FinishStream(StreamingState* aSctx);
  * @note This method will free the state pointer (@p aSctx).
  */
 DEEPSPEECH_EXPORT
-Metadata* DS_FinishStreamWithMetadata(StreamingState* aSctx);
+Result* DS_FinishStreamWithMetadata(StreamingState* aSctx, 
+                                    unsigned int numResults);
 
 /**
  * @brief Destroy a streaming state without decoding the computed logits. This
@@ -243,6 +255,12 @@ void DS_FreeStream(StreamingState* aSctx);
  */
 DEEPSPEECH_EXPORT
 void DS_FreeMetadata(Metadata* m);
+
+/**
+ * @brief Free memory allocated for result information.
+ */
+DEEPSPEECH_EXPORT
+void DS_FreeResult(Result* r);
 
 /**
  * @brief Free a char* string returned by the DeepSpeech API.

--- a/native_client/modelstate.cc
+++ b/native_client/modelstate.cc
@@ -34,32 +34,41 @@ ModelState::init(const char* model_path,
 char*
 ModelState::decode(const DecoderState& state)
 {
-  vector<Output> out = state.decode();
+  vector<Output> out = state.decode(1);
   return strdup(alphabet_.LabelsToString(out[0].tokens).c_str());
 }
 
-Metadata*
-ModelState::decode_metadata(const DecoderState& state)
+vector<Metadata*>
+ModelState::decode_metadata(const DecoderState& state, 
+                            size_t top_paths)
 {
-  vector<Output> out = state.decode();
+  vector<Output> out = state.decode(top_paths);
 
-  std::unique_ptr<Metadata> metadata(new Metadata());
-  metadata->num_items = out[0].tokens.size();
-  metadata->confidence = out[0].confidence;
+  vector<Metadata*> meta_out;
 
-  std::unique_ptr<MetadataItem[]> items(new MetadataItem[metadata->num_items]());
+  size_t max_results = std::min(top_paths, out.size());
 
-  // Loop through each character
-  for (int i = 0; i < out[0].tokens.size(); ++i) {
-    items[i].character = strdup(alphabet_.StringFromLabel(out[0].tokens[i]).c_str());
-    items[i].timestep = out[0].timesteps[i];
-    items[i].start_time = out[0].timesteps[i] * ((float)audio_win_step_ / sample_rate_);
+  for (int j = 0; j < max_results; ++j) {
+    std::unique_ptr<Metadata> metadata(new Metadata());
+    metadata->num_items = out[j].tokens.size();
+    metadata->confidence = out[j].confidence;
 
-    if (items[i].start_time < 0) {
-      items[i].start_time = 0;
+    std::unique_ptr<MetadataItem[]> items(new MetadataItem[metadata->num_items]());
+
+    // Loop through each character
+    for (int i = 0; i < out[j].tokens.size(); ++i) {
+      items[i].character = strdup(alphabet_.StringFromLabel(out[j].tokens[i]).c_str());
+      items[i].timestep = out[j].timesteps[i];
+      items[i].start_time = out[j].timesteps[i] * ((float)audio_win_step_ / sample_rate_);
+
+      if (items[i].start_time < 0) {
+        items[i].start_time = 0;
+      }
     }
+
+    metadata->items = items.release();
+    meta_out.push_back(metadata.release());
   }
 
-  metadata->items = items.release();
-  return metadata.release();
+  return meta_out;
 }

--- a/native_client/modelstate.h
+++ b/native_client/modelstate.h
@@ -66,11 +66,14 @@ struct ModelState {
    * @brief Return character-level metadata including letter timings.
    *
    * @param state Decoder state to use when decoding.
+   * @param top_paths Number of alternate results to return.   
    *
-   * @return Metadata struct containing MetadataItem structs for each character.
-   * The user is responsible for freeing Metadata by calling DS_FreeMetadata().
+   * @return Vector of Metadata structs containing MetadataItem structs for each character.
+   * Each represents an alternate transcription, with the first ranked most probable.
+   * The user is responsible for freeing Metadata by calling DS_FreeMetadata() on each item.
    */
-  virtual Metadata* decode_metadata(const DecoderState& state);
+  virtual std::vector<Metadata*> decode_metadata(const DecoderState& state, 
+                                            size_t top_paths);
 };
 
 #endif // MODELSTATE_H


### PR DESCRIPTION
Sample output:

```
[
{"metadata":{"confidence":-87.0209},"words":[{"word":"remark","time":0,"duration":0.56},{"word":"in","time":0.58,"duration":0.14},{"word":"response","time":0.72,"duration":0.56},{"word":"to","time":1.3,"duration":0.12},{"word":"events","time":1.42,"duration":0.56},{"word":"like","time":2.06,"duration":0.68},{"word":"approving","time":2.74,"duration":0.58},{"word":"affile","time":3.42,"duration":0.36}]},
{"metadata":{"confidence":-74.4723},"words":[{"word":"remark","time":0,"duration":0.56},{"word":"in","time":0.58,"duration":0.14},{"word":"response","time":0.72,"duration":0.56},{"word":"to","time":1.3,"duration":0.12},{"word":"events","time":1.42,"duration":0.56},{"word":"like","time":2.06,"duration":0.68},{"word":"approving","time":2.74,"duration":0.58},{"word":"a","time":3.42,"duration":0.0400002},{"word":"file","time":3.48,"duration":0.3}]},
{"metadata":{"confidence":-89.3516},"words":[{"word":"remark","time":0,"duration":0.56},{"word":"in","time":0.58,"duration":0.14},{"word":"response","time":0.72,"duration":0.56},{"word":"to","time":1.3,"duration":0.12},{"word":"a","time":1.42,"duration":0.02},{"word":"vent","time":1.58,"duration":0.4},{"word":"like","time":2.06,"duration":0.7},{"word":"approving","time":2.76,"duration":0.56},{"word":"affile","time":3.42,"duration":0.38}]}
]
```

Some notes:

1. Maybe Result isn't the best name for the struct but I wasn't really sure of the most suitable name to refer to it. Suggestions are welcome.

2. I chose to output from the client as a JSON array. But is it obvious that the top result is the "best" one? An alternative way to organize it would be:

```
{
"confidence": 1.0, 
"words": [{"word": "x", "time": 0}], 
"alternatives": [{"confidence": 0.9, "words":[{"word": "y", "time": 0}]},...] 
}
```

This would be closer to how Google's STT API works.

3. I hard-coded the client to output 3 transcriptions, which seemed reasonable. It is of course configurable to anyone using the API but I don't know if offering a command-line option to customize this in the client is worthwhile. Open to feedback on this.

Fixes #432 