### PR TITLE
Expose multiple transcriptions

### DIFF
--- a/native_client/ctcdecode/ctc_beam_search_decoder.cpp
+++ b/native_client/ctcdecode/ctc_beam_search_decoder.cpp
@@ -157,7 +157,7 @@ DecoderState::next(const double *probs,
 }
 
 std::vector<Output>
-DecoderState::decode() const
+DecoderState::decode(size_t top_paths) const
 {
   std::vector<PathTrie*> prefixes_copy = prefixes_;
   std::unordered_map<const PathTrie*, float> scores;
@@ -167,7 +167,7 @@ DecoderState::decode() const
 
   // score the last word of each prefix that doesn't end with space
   if (ext_scorer_ != nullptr) {
-    for (size_t i = 0; i < beam_size_ && i < prefixes_copy.size(); ++i) {
+    for (size_t i = 0; i < top_paths && i < prefixes_copy.size(); ++i) {
       auto prefix = prefixes_copy[i];
       if (!ext_scorer_->is_scoring_boundary(prefix->parent, prefix->character)) {
         float score = 0.0;
@@ -181,14 +181,12 @@ DecoderState::decode() const
   }
 
   using namespace std::placeholders;
-  size_t num_prefixes = std::min(prefixes_copy.size(), beam_size_);
+  size_t num_prefixes = std::min(prefixes_copy.size(), top_paths);
   std::partial_sort(prefixes_copy.begin(),
                     prefixes_copy.begin() + num_prefixes,
                     prefixes_copy.end(),
                     std::bind(prefix_compare_external, _1, _2, scores));
 
-  //TODO: expose this as an API parameter
-  const size_t top_paths = 1;
   size_t num_returned = std::min(num_prefixes, top_paths);
 
   std::vector<Output> outputs;
@@ -220,6 +218,7 @@ std::vector<Output> ctc_beam_search_decoder(
     int class_dim,
     const Alphabet &alphabet,
     size_t beam_size,
+    size_t top_paths,
     double cutoff_prob,
     size_t cutoff_top_n,
     Scorer *ext_scorer)
@@ -227,7 +226,7 @@ std::vector<Output> ctc_beam_search_decoder(
   DecoderState state;
   state.init(alphabet, beam_size, cutoff_prob, cutoff_top_n, ext_scorer);
   state.next(probs, time_dim, class_dim);
-  return state.decode();
+  return state.decode(top_paths);
 }
 
 std::vector<std::vector<Output>>
@@ -240,6 +239,7 @@ ctc_beam_search_decoder_batch(
     int seq_lengths_size,
     const Alphabet &alphabet,
     size_t beam_size,
+    size_t top_paths,
     size_t num_processes,
     double cutoff_prob,
     size_t cutoff_top_n,
@@ -259,6 +259,7 @@ ctc_beam_search_decoder_batch(
                                   class_dim,
                                   alphabet,
                                   beam_size,
+                                  top_paths,
                                   cutoff_prob,
                                   cutoff_top_n,
                                   ext_scorer));

--- a/native_client/deepspeech.cc
+++ b/native_client/deepspeech.cc
@@ -148,21 +148,7 @@ StreamingState::finishStreamWithMetadata(unsigned int num_results)
 {
   finalizeStream();
 
-  vector<Metadata*> metadata = model_->decode_metadata(decoder_state_, numResults);
-
-  std::unique_ptr<Result> result(new Result());
-  result->num_transcriptions = metadata.size();
-
-  std::unique_ptr<Metadata[]> items(new Metadata[result->num_transcriptions]);
-
-  for (int i = 0; i < result->num_transcriptions; ++i) {
-      std::unique_ptr<Metadata> pointer(new Metadata(*metadata[i]));
-      items[i] = *pointer.release();
-  }
-
-  result->transcriptions = items.release();
-
-  return result.release();
+  return model_->decode_metadata(decoder_state_, num_results);
 }
 
 void

--- a/native_client/deepspeech.cc
+++ b/native_client/deepspeech.cc
@@ -80,7 +80,7 @@ struct StreamingState {
   char* intermediateDecode();
   void finalizeStream();
   char* finishStream();
-  Result* finishStreamWithMetadata(unsigned int numResults);
+  Result* finishStreamWithMetadata(unsigned int num_results);
 
   void processAudioWindow(const vector<float>& buf);
   void processMfccWindow(const vector<float>& buf);
@@ -144,7 +144,7 @@ StreamingState::finishStream()
 }
 
 Result*
-StreamingState::finishStreamWithMetadata(unsigned int numResults)
+StreamingState::finishStreamWithMetadata(unsigned int num_results)
 {
   finalizeStream();
 
@@ -393,9 +393,9 @@ DS_FinishStream(StreamingState* aSctx)
 
 Result*
 DS_FinishStreamWithMetadata(StreamingState* aSctx, 
-                            unsigned int numResults)
+                            unsigned int aNumResults)
 {
-  Result* result = aSctx->finishStreamWithMetadata(numResults);
+  Result* result = aSctx->finishStreamWithMetadata(aNumResults);
   DS_FreeStream(aSctx);
   return result;
 }
@@ -427,10 +427,10 @@ Result*
 DS_SpeechToTextWithMetadata(ModelState* aCtx,
                             const short* aBuffer,
                             unsigned int aBufferSize,
-                            unsigned int numResults)
+                            unsigned int aNumResults)
 {
   StreamingState* ctx = CreateStreamAndFeedAudioContent(aCtx, aBuffer, aBufferSize);
-  return DS_FinishStreamWithMetadata(ctx, numResults);
+  return DS_FinishStreamWithMetadata(ctx, aNumResults);
 }
 
 void

--- a/native_client/deepspeech.h
+++ b/native_client/deepspeech.h
@@ -160,6 +160,7 @@ char* DS_SpeechToText(ModelState* aCtx,
  * @param aBuffer A 16-bit, mono raw audio signal at the appropriate
  *                sample rate (matching what the model was trained on).
  * @param aBufferSize The number of samples in the audio signal.
+ * @param aNumResults The number of alternative transcriptions to return.
  *
  * @return Outputs a struct of individual letters along with their timing information. 
  *         The user is responsible for freeing Metadata by calling {@link DS_FreeMetadata()}. Returns NULL on error.
@@ -168,7 +169,7 @@ DEEPSPEECH_EXPORT
 Result* DS_SpeechToTextWithMetadata(ModelState* aCtx,
                                     const short* aBuffer,
                                     unsigned int aBufferSize,
-                                    unsigned int numResults);
+                                    unsigned int aNumResults);
 
 /**
  * @brief Create a new streaming inference state. The streaming state returned
@@ -228,6 +229,7 @@ char* DS_FinishStream(StreamingState* aSctx);
  *        inference, returns per-letter metadata.
  *
  * @param aSctx A streaming state pointer returned by {@link DS_CreateStream()}.
+ * @param aNumResults The number of alternative transcriptions to return.
  *
  * @return Outputs a struct of individual letters along with their timing information. 
  *         The user is responsible for freeing Metadata by calling {@link DS_FreeMetadata()}. Returns NULL on error.
@@ -236,7 +238,7 @@ char* DS_FinishStream(StreamingState* aSctx);
  */
 DEEPSPEECH_EXPORT
 Result* DS_FinishStreamWithMetadata(StreamingState* aSctx, 
-                                    unsigned int numResults);
+                                    unsigned int aNumResults);
 
 /**
  * @brief Destroy a streaming state without decoding the computed logits. This

--- a/native_client/deepspeech.h
+++ b/native_client/deepspeech.h
@@ -48,6 +48,16 @@ typedef struct Metadata {
   double confidence;
 } Metadata;
 
+/**
+ * @brief Stores Metadata structs for each alternative transcription
+ */
+typedef struct Result {
+  /** List of transcriptions */
+  Metadata* transcriptions;
+  /** Size of the list of transcriptions */
+  int num_transcriptions;
+} Result;
+
 enum DeepSpeech_Error_Codes
 {
     // OK
@@ -155,9 +165,10 @@ char* DS_SpeechToText(ModelState* aCtx,
  *         The user is responsible for freeing Metadata by calling {@link DS_FreeMetadata()}. Returns NULL on error.
  */
 DEEPSPEECH_EXPORT
-Metadata* DS_SpeechToTextWithMetadata(ModelState* aCtx,
-                                      const short* aBuffer,
-                                      unsigned int aBufferSize);
+Result* DS_SpeechToTextWithMetadata(ModelState* aCtx,
+                                    const short* aBuffer,
+                                    unsigned int aBufferSize,
+                                    unsigned int numResults);
 
 /**
  * @brief Create a new streaming inference state. The streaming state returned
@@ -224,7 +235,8 @@ char* DS_FinishStream(StreamingState* aSctx);
  * @note This method will free the state pointer (@p aSctx).
  */
 DEEPSPEECH_EXPORT
-Metadata* DS_FinishStreamWithMetadata(StreamingState* aSctx);
+Result* DS_FinishStreamWithMetadata(StreamingState* aSctx, 
+                                    unsigned int numResults);
 
 /**
  * @brief Destroy a streaming state without decoding the computed logits. This
@@ -243,6 +255,12 @@ void DS_FreeStream(StreamingState* aSctx);
  */
 DEEPSPEECH_EXPORT
 void DS_FreeMetadata(Metadata* m);
+
+/**
+ * @brief Free memory allocated for result information.
+ */
+DEEPSPEECH_EXPORT
+void DS_FreeResult(Result* r);
 
 /**
  * @brief Free a char* string returned by the DeepSpeech API.

--- a/native_client/modelstate.cc
+++ b/native_client/modelstate.cc
@@ -34,22 +34,25 @@ ModelState::init(const char* model_path,
 char*
 ModelState::decode(const DecoderState& state)
 {
-  vector<Output> out = state.decode(1);
+  vector<Output> out = state.decode();
   return strdup(alphabet_.LabelsToString(out[0].tokens).c_str());
 }
 
-vector<Metadata*>
+Result*
 ModelState::decode_metadata(const DecoderState& state, 
-                            size_t top_paths)
+                            size_t num_results)
 {
-  vector<Output> out = state.decode(top_paths);
+  vector<Output> out = state.decode();
 
-  vector<Metadata*> meta_out;
+  size_t max_results = std::min(num_results, out.size());
 
-  size_t max_results = std::min(top_paths, out.size());
+  std::unique_ptr<Result> result(new Result());
+  result->num_transcriptions = max_results;
+
+  std::unique_ptr<Metadata[]> transcripts(new Metadata[max_results]());
 
   for (int j = 0; j < max_results; ++j) {
-    std::unique_ptr<Metadata> metadata(new Metadata());
+    Metadata* metadata = &transcripts[j];
     metadata->num_items = out[j].tokens.size();
     metadata->confidence = out[j].confidence;
 
@@ -67,8 +70,9 @@ ModelState::decode_metadata(const DecoderState& state,
     }
 
     metadata->items = items.release();
-    meta_out.push_back(metadata.release());
   }
 
-  return meta_out;
+  result->transcriptions = transcripts.release();
+
+  return result.release();
 }

--- a/native_client/modelstate.cc
+++ b/native_client/modelstate.cc
@@ -34,32 +34,41 @@ ModelState::init(const char* model_path,
 char*
 ModelState::decode(const DecoderState& state)
 {
-  vector<Output> out = state.decode();
+  vector<Output> out = state.decode(1);
   return strdup(alphabet_.LabelsToString(out[0].tokens).c_str());
 }
 
-Metadata*
-ModelState::decode_metadata(const DecoderState& state)
+vector<Metadata*>
+ModelState::decode_metadata(const DecoderState& state, 
+                            size_t top_paths)
 {
-  vector<Output> out = state.decode();
+  vector<Output> out = state.decode(top_paths);
 
-  std::unique_ptr<Metadata> metadata(new Metadata());
-  metadata->num_items = out[0].tokens.size();
-  metadata->confidence = out[0].confidence;
+  vector<Metadata*> meta_out;
 
-  std::unique_ptr<MetadataItem[]> items(new MetadataItem[metadata->num_items]());
+  size_t max_results = std::min(top_paths, out.size());
 
-  // Loop through each character
-  for (int i = 0; i < out[0].tokens.size(); ++i) {
-    items[i].character = strdup(alphabet_.StringFromLabel(out[0].tokens[i]).c_str());
-    items[i].timestep = out[0].timesteps[i];
-    items[i].start_time = out[0].timesteps[i] * ((float)audio_win_step_ / sample_rate_);
+  for (int j = 0; j < max_results; ++j) {
+    std::unique_ptr<Metadata> metadata(new Metadata());
+    metadata->num_items = out[j].tokens.size();
+    metadata->confidence = out[j].confidence;
 
-    if (items[i].start_time < 0) {
-      items[i].start_time = 0;
+    std::unique_ptr<MetadataItem[]> items(new MetadataItem[metadata->num_items]());
+
+    // Loop through each character
+    for (int i = 0; i < out[j].tokens.size(); ++i) {
+      items[i].character = strdup(alphabet_.StringFromLabel(out[j].tokens[i]).c_str());
+      items[i].timestep = out[j].timesteps[i];
+      items[i].start_time = out[j].timesteps[i] * ((float)audio_win_step_ / sample_rate_);
+
+      if (items[i].start_time < 0) {
+        items[i].start_time = 0;
+      }
     }
+
+    metadata->items = items.release();
+    meta_out.push_back(metadata.release());
   }
 
-  metadata->items = items.release();
-  return metadata.release();
+  return meta_out;
 }

--- a/native_client/modelstate.h
+++ b/native_client/modelstate.h
@@ -66,11 +66,14 @@ struct ModelState {
    * @brief Return character-level metadata including letter timings.
    *
    * @param state Decoder state to use when decoding.
+   * @param top_paths Number of alternate results to return.   
    *
-   * @return Metadata struct containing MetadataItem structs for each character.
-   * The user is responsible for freeing Metadata by calling DS_FreeMetadata().
+   * @return Vector of Metadata structs containing MetadataItem structs for each character.
+   * Each represents an alternate transcription, with the first ranked most probable.
+   * The user is responsible for freeing Metadata by calling DS_FreeMetadata() on each item.
    */
-  virtual Metadata* decode_metadata(const DecoderState& state);
+  virtual std::vector<Metadata*> decode_metadata(const DecoderState& state, 
+                                                 size_t top_paths);
 };
 
 #endif // MODELSTATE_H

--- a/native_client/modelstate.h
+++ b/native_client/modelstate.h
@@ -66,14 +66,14 @@ struct ModelState {
    * @brief Return character-level metadata including letter timings.
    *
    * @param state Decoder state to use when decoding.
-   * @param top_paths Number of alternate results to return.   
+   * @param num_results Number of alternate results to return.   
    *
-   * @return Vector of Metadata structs containing MetadataItem structs for each character.
+   * @return A Result struct containing Metadata structs.
    * Each represents an alternate transcription, with the first ranked most probable.
-   * The user is responsible for freeing Metadata by calling DS_FreeMetadata() on each item.
+   * The user is responsible for freeing Result by calling DS_FreeResult().
    */
-  virtual std::vector<Metadata*> decode_metadata(const DecoderState& state, 
-                                                 size_t top_paths);
+  virtual Result* decode_metadata(const DecoderState& state, 
+                                                 size_t num_results);
 };
 
 #endif // MODELSTATE_H


### PR DESCRIPTION
Sample output:

```
[
{"metadata":{"confidence":-87.0209},"words":[{"word":"remark","time":0,"duration":0.56},{"word":"in","time":0.58,"duration":0.14},{"word":"response","time":0.72,"duration":0.56},{"word":"to","time":1.3,"duration":0.12},{"word":"events","time":1.42,"duration":0.56},{"word":"like","time":2.06,"duration":0.68},{"word":"approving","time":2.74,"duration":0.58},{"word":"affile","time":3.42,"duration":0.36}]},
{"metadata":{"confidence":-74.4723},"words":[{"word":"remark","time":0,"duration":0.56},{"word":"in","time":0.58,"duration":0.14},{"word":"response","time":0.72,"duration":0.56},{"word":"to","time":1.3,"duration":0.12},{"word":"events","time":1.42,"duration":0.56},{"word":"like","time":2.06,"duration":0.68},{"word":"approving","time":2.74,"duration":0.58},{"word":"a","time":3.42,"duration":0.0400002},{"word":"file","time":3.48,"duration":0.3}]},
{"metadata":{"confidence":-89.3516},"words":[{"word":"remark","time":0,"duration":0.56},{"word":"in","time":0.58,"duration":0.14},{"word":"response","time":0.72,"duration":0.56},{"word":"to","time":1.3,"duration":0.12},{"word":"a","time":1.42,"duration":0.02},{"word":"vent","time":1.58,"duration":0.4},{"word":"like","time":2.06,"duration":0.7},{"word":"approving","time":2.76,"duration":0.56},{"word":"affile","time":3.42,"duration":0.38}]}
]
```

Some notes:

1. Maybe Result isn't the best name for the struct but I wasn't really sure of the most suitable name to refer to it. Suggestions are welcome.

2. I chose to output from the client as a JSON array. But is it obvious that the top result is the "best" one? An alternative way to organize it would be:

```
{
"confidence": 1.0, 
"words": [{"word": "x", "time": 0}], 
"alternatives": [{"confidence": 0.9, "words":[{"word": "y", "time": 0}]},...] 
}
```

This would be closer to how Google's STT API works.

3. I hard-coded the client to output 3 transcriptions, which seemed reasonable. It is of course configurable to anyone using the API but I don't know if offering a command-line option to customize this in the client is worthwhile. Open to feedback on this.

Fixes #432 