### PR TITLE
Remove extraneous OR operators in tc-tests-utils.sh

### DIFF
--- a/taskcluster/tc-tests-utils.sh
+++ b/taskcluster/tc-tests-utils.sh
@@ -259,7 +259,7 @@ assert_correct_ldc93s1_prodmodel()
     assert_correct_inference "$1" "she had reduce and greasy wash water all year" "$2"
   fi;
 
-  if [ -o "$3" = "8k" ]; then
+  if [ "$3" = "8k" ]; then
     assert_correct_inference "$1" "she had conduct suit in greasy wash water all year" "$2"
   fi;
 }
@@ -270,7 +270,7 @@ assert_correct_ldc93s1_prodtflitemodel()
     assert_correct_inference "$1" "she had i do utterly was or all year" "$2"
   fi;
 
-  if [ -o "$3" = "8k" ]; then
+  if [ "$3" = "8k" ]; then
     assert_correct_inference "$1" "she had conduct suit in greasy wash water all year" "$2"
   fi;
 }
@@ -281,7 +281,7 @@ assert_correct_ldc93s1_prodmodel_stereo_44k()
     assert_correct_inference "$1" "she had reduce and greasy wash water all year" "$2"
   fi;
 
-  if [ -o "$3" = "8k" ]; then
+  if [ "$3" = "8k" ]; then
     assert_correct_inference "$1" "she had conduct suit in greasy wash water all year" "$2"
   fi;
 }
@@ -292,7 +292,7 @@ assert_correct_ldc93s1_prodtflitemodel_stereo_44k()
     assert_correct_inference "$1" "she headed grey was or all year" "$2"
   fi;
 
-  if [ -o "$3" = "8k" ]; then
+  if [ "$3" = "8k" ]; then
     assert_correct_inference "$1" "she had conduct suit in greasy wash water all year" "$2"
   fi;
 }

--- a/taskcluster/tc-tests-utils.sh
+++ b/taskcluster/tc-tests-utils.sh
@@ -468,7 +468,7 @@ run_prod_concurrent_stream_tests()
              --model ${TASKCLUSTER_TMP_DIR}/${model_name_mmap} \
              --lm ${TASKCLUSTER_TMP_DIR}/lm.binary \
              --trie ${TASKCLUSTER_TMP_DIR}/trie \
-             --audio1 ${TASKCLUSTER_TMP_DIR}/${ldc93s1_sample_filename} \
+             --audio1 ${TASKCLUSTER_TMP_DIR}/LDC93S1_pcms16le_1_16000.wav \
              --audio2 ${TASKCLUSTER_TMP_DIR}/new-home-in-the-stars-16k.wav 2>${TASKCLUSTER_TMP_DIR}/stderr)
   status=$?
   set -e
@@ -476,7 +476,7 @@ run_prod_concurrent_stream_tests()
   output1=$(echo "${output}" | head -n 1)
   output2=$(echo "${output}" | tail -n 1)
 
-  assert_correct_ldc93s1_prodmodel "${output1}" "${status}" "${_bitrate}"
+  assert_correct_ldc93s1_prodmodel "${output1}" "${status}" "16k"
   assert_correct_inference "${output2}" "we must find a new home in the stars" "${status}"
 }
 

--- a/taskcluster/tc-tests-utils.sh
+++ b/taskcluster/tc-tests-utils.sh
@@ -271,7 +271,7 @@ assert_correct_ldc93s1_prodtflitemodel()
   fi;
 
   if [ "$3" = "8k" ]; then
-    assert_correct_inference "$1" "she had conduct suit in greasy wash water all year" "$2"
+    assert_correct_inference "$1" "she had up a out and we wash or a" "$2"
   fi;
 }
 
@@ -282,7 +282,7 @@ assert_correct_ldc93s1_prodmodel_stereo_44k()
   fi;
 
   if [ "$3" = "8k" ]; then
-    assert_correct_inference "$1" "she had conduct suit in greasy wash water all year" "$2"
+    assert_correct_inference "$1" "she had reduce and greasy wash water all year" "$2"
   fi;
 }
 
@@ -293,7 +293,7 @@ assert_correct_ldc93s1_prodtflitemodel_stereo_44k()
   fi;
 
   if [ "$3" = "8k" ]; then
-    assert_correct_inference "$1" "she had conduct suit in greasy wash water all year" "$2"
+    assert_correct_inference "$1" "she headed grey was or all year" "$2"
   fi;
 }
 


### PR DESCRIPTION
Fixes:

+ '[' -o 16k = 8k ']'
/home/build-user/DeepSpeech/ds/taskcluster/tc-tests-utils.sh: line 262: [: too many arguments