### PR TITLE
made the webrtcvad dependency optional

### DIFF
--- a/util/audio.py
+++ b/util/audio.py
@@ -3,7 +3,6 @@ import sox
 import wave
 import tempfile
 import collections
-from webrtcvad import Vad
 
 DEFAULT_RATE = 16000
 DEFAULT_CHANNELS = 1
@@ -90,6 +89,7 @@ def vad_split(audio_frames,
               num_padding_frames=10,
               threshold=0.5,
               aggressiveness=3):
+from webrtcvad import Vad
     sample_rate, channels, width = audio_format
     if channels != 1:
         raise ValueError('VAD-splitting requires mono samples')

--- a/util/audio.py
+++ b/util/audio.py
@@ -89,7 +89,7 @@ def vad_split(audio_frames,
               num_padding_frames=10,
               threshold=0.5,
               aggressiveness=3):
-from webrtcvad import Vad
+    from webrtcvad import Vad
     sample_rate, channels, width = audio_format
     if channels != 1:
         raise ValueError('VAD-splitting requires mono samples')


### PR DESCRIPTION
based on the small issue discussion

https://github.com/mozilla/DeepSpeech/issues/2752

I've moved the line to import `webrtcvad` into the `vad_split ` function