### PR TITLE
Add decompression of mmappable executable to documentation

### DIFF
--- a/doc/TRAINING.rst
+++ b/doc/TRAINING.rst
@@ -193,6 +193,14 @@ TensorFlow has tooling to achieve this: it requires building the target ``//tens
 
    $ python3 util/taskcluster.py --source tensorflow --artifact convert_graphdef_memmapped_format --branch r1.15 --target .
 
+You will need to rename the artifact to decompress it and then mark it as an executable:
+
+.. code-block::
+
+   $ mv convert_graphdef_memmapped_format convert_graphdef_memmapped_format.gz
+   $ gzip -d convert_graphdef_memmapped_format.gz
+   $ chmod +x convert_graphdef_memmapped_format
+
 Producing a mmap-able model is as simple as:
 
 .. code-block::


### PR DESCRIPTION
The `TRAINING.rst` documentation isn't correct. When I download the `convert_graphdef_memmapped_format` executable it is actually compressed gzip file and not an executable.

On my MacOS 10.15, I get:

```sh
$ file convert_graphdef_memmapped_format
convert_graphdef_memmapped_format: gzip compressed data, was "convert_graphdef_memmapped_format", original size modulo 2^32 198519040
```

To resolve this, I had to rename the file to have a `.gz` extension, decompress, and *then* execute the command. I added this to the doc.

I really love the project, but it really needs some better doc and stable API :)

Signed-off-by: Anas Abou Allaban <aabouallaban@pm.me>