### PR TITLE
Add a better __repr__ for Metadata objects in Python bindings

### DIFF
--- a/native_client/python/impl.i
+++ b/native_client/python/impl.i
@@ -46,6 +46,23 @@ import_array();
   }
 %}
 
+%extend struct MetadataItem {
+%pythoncode %{
+  def __repr__(self):
+    return 'MetadataItem(character=\'{}\', timestep={}, start_time={})'.format(self.character, self.timestep, self.start_time)
+%}
+}
+
+%extend struct Metadata {
+%pythoncode %{
+  def __repr__(self):
+    items_repr = ', \n'.join('  ' + repr(i) for i in self.items)
+    return 'Metadata(confidence={}, items=[\n{}\n])'.format(self.confidence, items_repr)
+%}
+}
+
+%ignore Metadata::num_items;
+
 %extend struct Metadata {
   ~Metadata() {
     DS_FreeMetadata($self);

--- a/native_client/python/setup.py
+++ b/native_client/python/setup.py
@@ -64,7 +64,7 @@ def main():
                        include_dirs=[numpy_include, '../'],
                        library_dirs=list(map(lambda x: x.strip(), lib_dirs_split(os.getenv('MODEL_LDFLAGS', '')))),
                        libraries=list(map(lambda x: x.strip(), libs_split(os.getenv('MODEL_LIBS', '')))),
-                       swig_opts=['-c++', '-keyword', '-builtin'])
+                       swig_opts=['-c++', '-keyword'])
 
     setup(name=project_name,
           description='A library for running inference on a DeepSpeech model',


### PR DESCRIPTION
How it looks:

```python
In [1]: from deepspeech import Model

In [2]: import scipy.io.wavfile as wav

In [3]: rate, samples = wav.read('data/ldc93s1/LDC93S1_clipped.wav')

In [4]: m = Model('/Users/reubenmorais/Downloads/models/output_graph.pbmm')
TensorFlow: v1.15.0-22-gbd115ee104
DeepSpeech: v0.7.0-alpha.2-8-g1c69d93b

In [5]: md = m.sttWithMetadata(samples)

In [6]: md
Out[6]:
Metadata(confidence=7.3753743171691895, items=[
  MetadataItem(character='s', timestep=0, start_time=0.0),
  MetadataItem(character='h', timestep=1, start_time=0.019999999552965164),
  MetadataItem(character='e', timestep=20, start_time=0.3999999761581421),
  MetadataItem(character=' ', timestep=22, start_time=0.4399999976158142),
  MetadataItem(character='h', timestep=25, start_time=0.5),
  MetadataItem(character='a', timestep=28, start_time=0.5600000023841858),
  MetadataItem(character='d', timestep=30, start_time=0.5999999642372131),
  MetadataItem(character=' ', timestep=34, start_time=0.6800000071525574),
  MetadataItem(character='y', timestep=36, start_time=0.7199999690055847),
  MetadataItem(character='e', timestep=38, start_time=0.7599999904632568),
  MetadataItem(character='r', timestep=40, start_time=0.7999999523162842),
  MetadataItem(character='t', timestep=41, start_time=0.8199999928474426),
  MetadataItem(character='e', timestep=43, start_time=0.85999995470047)
])

In [7]: md.items[0]
Out[7]: MetadataItem(character='s', timestep=0, start_time=0.0)

In [8]: md.items[0].character
Out[8]: 's'
```