### PR TITLE
Report error code as hexadecimal numbers for easier lookup

### DIFF
--- a/native_client/javascript/index.js
+++ b/native_client/javascript/index.js
@@ -35,7 +35,7 @@ function Model(aModelPath) {
     const status = rets[0];
     const impl = rets[1];
     if (status !== 0) {
-        throw "CreateModel failed with error code " + status;
+        throw "CreateModel failed with error code 0x" + status.toString(16);
     }
 
     this._impl = impl;
@@ -138,7 +138,7 @@ Model.prototype.createStream = function() {
     const status = rets[0];
     const ctx = rets[1];
     if (status !== 0) {
-        throw "CreateStream failed with error code " + status;
+        throw "CreateStream failed with error code 0x" + status.toString(16);
     }
     return ctx;
 }

--- a/native_client/python/__init__.py
+++ b/native_client/python/__init__.py
@@ -35,7 +35,7 @@ class Model(object):
 
         status, impl = deepspeech.impl.CreateModel(model_path)
         if status != 0:
-            raise RuntimeError("CreateModel failed with error code {}".format(status))
+            raise RuntimeError("CreateModel failed with error code 0x{:X}".format(status))
         self._impl = impl
 
     def __del__(self):
@@ -145,7 +145,7 @@ class Model(object):
         """
         status, ctx = deepspeech.impl.CreateStream(self._impl)
         if status != 0:
-            raise RuntimeError("CreateStream failed with error code {}".format(status))
+            raise RuntimeError("CreateStream failed with error code 0x{:X}".format(status))
         return Stream(ctx)
 
 


### PR DESCRIPTION
They're written as hexadecimals in the header so this makes it easier to lookup the error name. We should probably add a [strerror](https://linux.die.net/man/3/strerror)-like API as well.