### PR TITLE
Add flag to force reinitialisation of learning rate after lr_plateau

### DIFF
--- a/util/checkpoints.py
+++ b/util/checkpoints.py
@@ -18,7 +18,7 @@ def _load_checkpoint(session, checkpoint_path):
     # We explicitly allow the learning rate variable to be missing for backwards
     # compatibility with older checkpoints.
     lr_var = set(v for v in load_vars if v.op.name == 'learning_rate')
-    if lr_var and 'learning_rate' not in vars_in_ckpt:
+    if lr_var and ('learning_rate' not in vars_in_ckpt or FLAGS.force_initialize_learning_rate):
         assert len(lr_var) <= 1
         load_vars -= lr_var
         init_vars |= lr_var

--- a/util/flags.py
+++ b/util/flags.py
@@ -148,6 +148,7 @@ def create_flags():
     f.DEFINE_boolean('reduce_lr_on_plateau', False, 'Enable reducing the learning rate if a plateau is reached. This is the case if the validation loss did not improve for some epochs.')
     f.DEFINE_integer('plateau_epochs', 10, 'Number of epochs to consider for RLROP. Has to be smaller than es_epochs from early stopping')
     f.DEFINE_float('plateau_reduction', 0.1, 'Multiplicative factor to apply to the current learning rate if a plateau has occurred.')
+    f.DEFINE_float('force_initialize_learning_rate', False, 'Force re-initialization of learning rate which was previously reduced.')
 
     # Decoder
 

--- a/util/flags.py
+++ b/util/flags.py
@@ -148,7 +148,7 @@ def create_flags():
     f.DEFINE_boolean('reduce_lr_on_plateau', False, 'Enable reducing the learning rate if a plateau is reached. This is the case if the validation loss did not improve for some epochs.')
     f.DEFINE_integer('plateau_epochs', 10, 'Number of epochs to consider for RLROP. Has to be smaller than es_epochs from early stopping')
     f.DEFINE_float('plateau_reduction', 0.1, 'Multiplicative factor to apply to the current learning rate if a plateau has occurred.')
-    f.DEFINE_float('force_initialize_learning_rate', False, 'Force re-initialization of learning rate which was previously reduced.')
+    f.DEFINE_boolean('force_initialize_learning_rate', False, 'Force re-initialization of learning rate which was previously reduced.')
 
     # Decoder
 


### PR DESCRIPTION
When using reduce_lr_on_plateau, the reduced learning rate is saved in the checkpoint. If you want to resume from the checkpoint at a higher learning rate (passed in by --learning_rate) then you can set this flag.