### PR TITLE
Enhancement debian package manager tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04
 
 # Get basic packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        apt-utils \
+        ca-certificates \
         build-essential \
         curl \
         wget \
@@ -44,14 +46,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN ln -s -f /usr/bin/python3 /usr/bin/python
 
 # Install NCCL 2.2
-RUN apt-get install -qq -y --allow-downgrades --allow-change-held-packages libnccl2=2.3.7-1+cuda10.0 libnccl-dev=2.3.7-1+cuda10.0
+RUN apt-get --no-install-recommends install -qq -y --allow-downgrades --allow-change-held-packages libnccl2=2.3.7-1+cuda10.0 libnccl-dev=2.3.7-1+cuda10.0
 
 # Install Bazel
 RUN curl -LO "https://github.com/bazelbuild/bazel/releases/download/0.24.1/bazel_0.24.1-linux-x86_64.deb"
 RUN dpkg -i bazel_*.deb
 
 # Install CUDA CLI Tools
-RUN apt-get install -qq -y cuda-command-line-tools-10-0
+RUN apt-get --no-install-recommends install -qq -y cuda-command-line-tools-10-0
 
 # Install pip
 RUN wget https://bootstrap.pypa.io/get-pip.py && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,6 @@ FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu18.04
 # Get basic packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
         apt-utils \
-        ca-certificates \
         build-essential \
         curl \
         wget \


### PR DESCRIPTION
Major Changes No 1 : debian package manager tweaks

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Major Changes No 2 : added packages apt-utils ca-certificates

Because build is 

1.  Slow and in log it is showing because "apt-utils" not installed 

2. to avoid build to exits with error without having certificate