### PR TITLE
README update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ DeepSpeech is an open source Speech-To-Text engine, using a model trained by mac
 
 To install and use the **latest stable version**, please see the `DeepSpeech install guide <http://deepspeech.readthedocs.io/?badge=latest>`_  available at `deepspeech.readthedocs.io <http://deepspeech.readthedocs.io/?badge=latest>`_.
 
-To install the current release:
+To install the current stable release:
 
 .. code-block:: bash
 

--- a/README.rst
+++ b/README.rst
@@ -14,18 +14,22 @@ Project DeepSpeech
 
 DeepSpeech is an open source Speech-To-Text engine, using a model trained by machine learning techniques based on `Baidu's Deep Speech research paper <https://arxiv.org/abs/1412.5567>`_. Project DeepSpeech uses Google's `TensorFlow <https://www.tensorflow.org/>`_ to make the implementation easier.
 
-**NOTE:** This documentation applies to the **MASTER version** of DeepSpeech only. **Documentation for the latest stable version** is published on `deepspeech.readthedocs.io <http://deepspeech.readthedocs.io/?badge=latest>`_.
+To install and use the **latest stable version**, please see the `DeepSpeech install guide <http://deepspeech.readthedocs.io/?badge=latest>`_  available at `deepspeech.readthedocs.io <http://deepspeech.readthedocs.io/?badge=latest>`_.
 
-To install and use deepspeech all you have to do is:
+To install the current release:
+
+.. code-block:: bash
+
+   # Install DeepSpeech
+   pip3 install deepspeech
+
+If you're using the **MASTER version** of DeepSpeech, you can get started using a pre-trained model:
 
 .. code-block:: bash
 
    # Create and activate a virtualenv
    virtualenv -p python3 $HOME/tmp/deepspeech-venv/
    source $HOME/tmp/deepspeech-venv/bin/activate
-
-   # Install DeepSpeech
-   pip3 install deepspeech
 
    # Download pre-trained English model and extract
    curl -LO https://github.com/mozilla/DeepSpeech/releases/download/v0.6.1/deepspeech-0.6.1-models.tar.gz
@@ -61,7 +65,7 @@ See the output of ``deepspeech -h`` for more information on the use of ``deepspe
 ----
 
 **Table of Contents**
-  
+
 * `Using a Pre-trained Model <doc/USING.rst#using-a-pre-trained-model>`_
 
   * `CUDA dependency <doc/USING.rst#cuda-dependency>`_


### PR DESCRIPTION
I took some inspiration from the [tensorflow readme](https://github.com/tensorflow/tensorflow) to:

1. Point to a separate install guide. I highlighted readthedocs here (I can followup with a PR to update the docs to include an install guide)
2. Separate out installing the current release with pip from using the pre-trained models on master. Note: I'm not sure that keeping the 0.6.1 models with 0.7 syntax here makes sense, but I'm leaving it in for now.

Based on my experience and feedback here: https://discourse.mozilla.org/t/installing-deep-speech-for-the-first-time-thinking-out-loud