### PR TITLE
Add trial pruning to lm_optimizer.py

### DIFF
--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -75,7 +75,7 @@ def create_overlapping_windows(batch_x):
 
 
 def dense(name, x, units, dropout_rate=None, relu=True):
-    with tfv1.variable_scope(name):
+    with tfv1.variable_scope(name, reuse=tf.AUTO_REUSE):
         bias = variable_on_cpu('bias', [units], tfv1.zeros_initializer())
         weights = variable_on_cpu('weights', [x.shape[-1], units], tfv1.keras.initializers.VarianceScaling(scale=1.0, mode="fan_avg", distribution="uniform"))
 
@@ -91,7 +91,7 @@ def dense(name, x, units, dropout_rate=None, relu=True):
 
 
 def rnn_impl_lstmblockfusedcell(x, seq_length, previous_state, reuse):
-    with tfv1.variable_scope('cudnn_lstm/rnn/multi_rnn_cell/cell_0'):
+    with tfv1.variable_scope('cudnn_lstm/rnn/multi_rnn_cell/cell_0', reuse=tf.AUTO_REUSE):
         fw_cell = tf.contrib.rnn.LSTMBlockFusedCell(Config.n_cell_dim,
                                                     forget_bias=0,
                                                     reuse=reuse,
@@ -133,7 +133,7 @@ rnn_impl_cudnn_rnn.cell = None
 
 
 def rnn_impl_static_rnn(x, seq_length, previous_state, reuse):
-    with tfv1.variable_scope('cudnn_lstm/rnn/multi_rnn_cell'):
+    with tfv1.variable_scope('cudnn_lstm/rnn/multi_rnn_cell', reuse=tf.AUTO_REUSE):
         # Forward direction cell:
         fw_cell = tfv1.nn.rnn_cell.LSTMCell(Config.n_cell_dim,
                                             forget_bias=0,

--- a/DeepSpeech.py
+++ b/DeepSpeech.py
@@ -75,7 +75,7 @@ def create_overlapping_windows(batch_x):
 
 
 def dense(name, x, units, dropout_rate=None, relu=True):
-    with tfv1.variable_scope(name, reuse=tf.AUTO_REUSE):
+    with tfv1.variable_scope(name):
         bias = variable_on_cpu('bias', [units], tfv1.zeros_initializer())
         weights = variable_on_cpu('weights', [x.shape[-1], units], tfv1.keras.initializers.VarianceScaling(scale=1.0, mode="fan_avg", distribution="uniform"))
 
@@ -91,7 +91,7 @@ def dense(name, x, units, dropout_rate=None, relu=True):
 
 
 def rnn_impl_lstmblockfusedcell(x, seq_length, previous_state, reuse):
-    with tfv1.variable_scope('cudnn_lstm/rnn/multi_rnn_cell/cell_0', reuse=tf.AUTO_REUSE):
+    with tfv1.variable_scope('cudnn_lstm/rnn/multi_rnn_cell/cell_0'):
         fw_cell = tf.contrib.rnn.LSTMBlockFusedCell(Config.n_cell_dim,
                                                     forget_bias=0,
                                                     reuse=reuse,
@@ -133,7 +133,7 @@ rnn_impl_cudnn_rnn.cell = None
 
 
 def rnn_impl_static_rnn(x, seq_length, previous_state, reuse):
-    with tfv1.variable_scope('cudnn_lstm/rnn/multi_rnn_cell', reuse=tf.AUTO_REUSE):
+    with tfv1.variable_scope('cudnn_lstm/rnn/multi_rnn_cell'):
         # Forward direction cell:
         fw_cell = tfv1.nn.rnn_cell.LSTMCell(Config.n_cell_dim,
                                             forget_bias=0,

--- a/lm_optimizer.py
+++ b/lm_optimizer.py
@@ -28,12 +28,12 @@ def objective(trial):
     FLAGS.lm_alpha = trial.suggest_uniform('lm_alpha', 0, FLAGS.lm_alpha_max)
     FLAGS.lm_beta = trial.suggest_uniform('lm_beta', 0, FLAGS.lm_beta_max)
 
-    tfv1.reset_default_graph()
-
     is_character_based = trial.study.user_attrs['is_character_based']
 
     samples = []
     for step, test_file in enumerate(FLAGS.test_files.split(',')):
+        tfv1.reset_default_graph()
+
         current_samples = evaluate([test_file], create_model, try_loading)
         samples += current_samples
 

--- a/lm_optimizer.py
+++ b/lm_optimizer.py
@@ -34,7 +34,7 @@ def objective(trial):
     for step, test_file in enumerate(FLAGS.test_files.split(',')):
         tfv1.reset_default_graph()
 
-        current_samples = evaluate([test_file], create_model, try_loading)
+        current_samples = evaluate([test_file], create_model)
         samples += current_samples
 
         # Report intermediate objective value.

--- a/lm_optimizer.py
+++ b/lm_optimizer.py
@@ -29,9 +29,21 @@ def objective(trial):
     FLAGS.lm_beta = trial.suggest_uniform('lm_beta', 0, FLAGS.lm_beta_max)
 
     tfv1.reset_default_graph()
-    samples = evaluate(FLAGS.test_files.split(','), create_model)
 
     is_character_based = trial.study.user_attrs['is_character_based']
+
+    samples = []
+    for step, test_file in enumerate(FLAGS.test_files.split(',')):
+        current_samples = evaluate([test_file], create_model, try_loading)
+        samples += current_samples
+
+        # Report intermediate objective value.
+        wer, cer = wer_cer_batch(current_samples)
+        trial.report(cer if is_character_based else wer, step)
+
+        # Handle pruning based on the intermediate value.
+        if trial.should_prune():
+            raise optuna.exceptions.TrialPruned()
 
     wer, cer = wer_cer_batch(samples)
     return cer if is_character_based else wer


### PR DESCRIPTION
This is an addendum to PR #2783 which adds trial pruning to the language model hyperparameter optimiser, documented here: https://optuna.readthedocs.io/en/latest/tutorial/pruning.html

The idea is to break the model inference into multiple steps so that trials can be abandoned early if the results look unpromising. I assumed that the user supplied multiple csv to the `test_files` flag in `utils/flags.py` and split the work across those. The user probably has to provide around 10 files for the feature to be useful.

I had to modify the calls to `variable_scope` in `DeepSpeech.py` in order to reuse the model across the multiple trials when it already exists.