### PR TITLE
Fixed sample rate logic in Python client

### DIFF
--- a/native_client/python/client.py
+++ b/native_client/python/client.py
@@ -128,14 +128,14 @@ def main():
             ds.setScorerAlphaBeta(args.lm_alpha, args.lm_beta)
 
     fin = wave.open(args.audio, 'rb')
-    fs = fin.getframerate()
-    if fs != desired_sample_rate:
-        print('Warning: original sample rate ({}) is different than {}hz. Resampling might produce erratic speech recognition.'.format(fs, desired_sample_rate), file=sys.stderr)
-        fs, audio = convert_samplerate(args.audio, desired_sample_rate)
+    fs_orig = fin.getframerate()
+    if fs_orig != desired_sample_rate:
+        print('Warning: original sample rate ({}) is different than {}hz. Resampling might produce erratic speech recognition.'.format(fs_orig, desired_sample_rate), file=sys.stderr)
+        fs_new, audio = convert_samplerate(args.audio, desired_sample_rate)
     else:
         audio = np.frombuffer(fin.readframes(fin.getnframes()), np.int16)
 
-    audio_length = fin.getnframes() * (1/fs)
+    audio_length = fin.getnframes() * (1/fs_orig)
     fin.close()
 
     print('Running inference.', file=sys.stderr)


### PR DESCRIPTION
Noticed that the python client reports an incorrect duration value if transcribing audio with sample rate != 16kHz. 

The getnframes() method counts the frames directly from the wav file, while the fs var is always set to the desired 16000 sample rate when it is passed back from the convert_samplerate function, so the duration calculation is incorrect. 

Wasn't sure if I should edit the convert_samplerate function directly or make 2 distinct vars, but I ultimately decided on making 2 vars, so that the convert_samplerate function returns the usual samplerate, audio_vector tuple.