### PR TITLE
Support building ctc_decoder wheel package on Windows system

### DIFF
--- a/native_client/ctcdecode/Makefile
+++ b/native_client/ctcdecode/Makefile
@@ -16,12 +16,14 @@ GENERATE_DEBUG_SYMS :=
 endif
 
 ifeq ($(findstring _NT,$(OS)),_NT)
-	FIRST_PARTY := first_party.lib
-	THIRD_PARTY := third_party.lib
+	ARCHIVE_EXT := lib
 else
-	FIRST_PARTY := first_party.a
-	THIRD_PARTY := third_party.a
+	ARCHIVE_EXT := a
 endif
+
+FIRST_PARTY := first_party.$(ARCHIVE_EXT)
+THIRD_PARTY := third_party.$(ARCHIVE_EXT)
+
 
 all: bindings
 

--- a/native_client/ctcdecode/Makefile
+++ b/native_client/ctcdecode/Makefile
@@ -15,14 +15,22 @@ else
 GENERATE_DEBUG_SYMS :=
 endif
 
+ifeq ($(findstring _NT,$(OS)),_NT)
+	FIRST_PARTY := first_party.lib
+	THIRD_PARTY := third_party.lib
+else
+	FIRST_PARTY := first_party.a
+	THIRD_PARTY := third_party.a
+endif
+
 all: bindings
 
 clean-keep-third-party:
 	rm -rf dist temp_build ds_ctcdecoder.egg-info
-	rm -f swigwrapper_wrap.cpp swigwrapper.py first_party.a
+	rm -f swigwrapper_wrap.cpp swigwrapper.py $(FIRST_PARTY)
 
 clean: clean-keep-third-party
-	rm -f third_party.a
+	rm -f $(THIRD_PARTY)
 	rm workspace_status.cc
 	rm -fr bazel-out/
 

--- a/native_client/ctcdecode/build_archive.py
+++ b/native_client/ctcdecode/build_archive.py
@@ -15,7 +15,7 @@ if sys.platform.startswith('win'):
     DBG_ARGS = ['/Od', '/MTd', '/Zi', '/U NDEBUG', '/D DEBUG']
     OPENFST_DIR = 'third_party/openfst-1.6.9-win'
 else:
-    ARGS = ['fPIC', '-DKENLM_MAX_ORDER=6', '-std=c++11', '-Wno-unused-local-typedefs', '-Wno-sign-compare']
+    ARGS = ['-fPIC', '-DKENLM_MAX_ORDER=6', '-std=c++11', '-Wno-unused-local-typedefs', '-Wno-sign-compare']
     OPT_ARGS = ['-O3', '-DNDEBUG']
     DBG_ARGS = ['-O0', '-g', '-UNDEBUG', '-DDEBUG']
     OPENFST_DIR = 'third_party/openfst-1.6.7'

--- a/native_client/ctcdecode/build_archive.py
+++ b/native_client/ctcdecode/build_archive.py
@@ -9,14 +9,23 @@ import sys
 
 from multiprocessing.dummy import Pool
 
-ARGS = ['-DKENLM_MAX_ORDER=6', '-std=c++11', '-Wno-unused-local-typedefs', '-Wno-sign-compare']
-OPT_ARGS = ['-O3', '-DNDEBUG']
-DBG_ARGS = ['-O0', '-g', '-UNDEBUG', '-DDEBUG']
+if sys.platform.startswith('win'):
+    ARGS = ['/nologo', '/D KENLM_MAX_ORDER=6', '/EHsc', '/source-charset:utf-8']
+    OPT_ARGS = ['/O2', '/MT', '/D NDEBUG']
+    DBG_ARGS = ['/Od', '/MTd', '/Zi', '/U NDEBUG', '/D DEBUG']
+    OPENFST_DIR = 'third_party/openfst-1.6.9-win'
+else:
+    ARGS = ['-DKENLM_MAX_ORDER=6', '-std=c++11', '-Wno-unused-local-typedefs', '-Wno-sign-compare']
+    OPT_ARGS = ['-O3', '-DNDEBUG']
+    DBG_ARGS = ['-O0', '-g', '-UNDEBUG', '-DDEBUG']
+    OPENFST_DIR = 'third_party/openfst-1.6.7'
+
+
 
 INCLUDES = [
     '..',
     '../kenlm',
-    'third_party/openfst-1.6.7/src/include',
+    OPENFST_DIR + '/src/include',
     'third_party/ThreadPool'
 ]
 
@@ -24,7 +33,7 @@ KENLM_FILES = (glob.glob('../kenlm/util/*.cc')
                 + glob.glob('../kenlm/lm/*.cc')
                 + glob.glob('../kenlm/util/double-conversion/*.cc'))
 
-KENLM_FILES += glob.glob('third_party/openfst-1.6.7/src/lib/*.cc')
+KENLM_FILES += glob.glob(OPENFST_DIR + '/src/lib/*.cc')
 
 KENLM_FILES = [
     fn for fn in KENLM_FILES
@@ -59,14 +68,25 @@ def build_archive(srcs=[], out_name='', build_dir='temp_build/temp_build', debug
         if os.path.exists(outfile):
             return
 
-        cmd = '{cc} -fPIC -c {cflags} {args} {includes} {infile} -o {outfile}'.format(
-            cc=compiler,
-            cflags=cflags,
-            args=' '.join(args),
-            includes=' '.join('-I' + i for i in INCLUDES),
-            infile=file,
-            outfile=outfile,
-        )
+        if sys.platform.startswith('win'):
+            cmd = '"{cc}" -c {cflags} {args} {includes} {infile} -Fo"{outfile}"'.format(
+                cc=compiler,
+                cflags=cflags,
+                args=' '.join(args),
+                includes=' '.join('-I' + i for i in INCLUDES),
+                infile=file,
+                outfile=outfile,
+            )
+            cmd = cmd.replace('\\', '/')
+        else:
+            cmd = '{cc} -fPIC -c {cflags} {args} {includes} {infile} -o {outfile}'.format(
+                cc=compiler,
+                cflags=cflags,
+                args=' '.join(args),
+                includes=' '.join('-I' + i for i in INCLUDES),
+                infile=file,
+                outfile=outfile,
+            )
         print(cmd)
         subprocess.check_call(shlex.split(cmd))
         return outfile
@@ -80,6 +100,15 @@ def build_archive(srcs=[], out_name='', build_dir='temp_build/temp_build', debug
             outfile=out_name,
             infiles=' '.join(obj_files),
         )
+        print(cmd)
+        subprocess.check_call(shlex.split(cmd))
+    elif sys.platform.startswith('win'):
+        obj_files = [s for s in obj_files if s != None]
+        cmd = '"lib.exe" /OUT:"{outfile}" {infiles} /MACHINE:X64 /NOLOGO'.format(
+            ar=ar,
+            outfile=out_name,
+            infiles=' '.join(obj_files))
+        cmd = cmd.replace('\\', '/')
         print(cmd)
         subprocess.check_call(shlex.split(cmd))
     else:

--- a/native_client/ctcdecode/setup.py
+++ b/native_client/ctcdecode/setup.py
@@ -54,12 +54,15 @@ def maybe_rebuild(srcs, out_name, build_dir):
 project_version = read('../../VERSION').strip()
 
 build_dir = 'temp_build/temp_build'
+
 if sys.platform.startswith('win'):
-    third_party_build = 'third_party.lib'
-    ctc_decoder_build = 'first_party.lib'
+    archive_ext = 'lib'
 else:
-    third_party_build = 'third_party.a'
-    ctc_decoder_build = 'first_party.a'
+    archive_ext = 'a'
+
+third_party_build = 'third_party.{}'.format(archive_ext)
+ctc_decoder_build = 'first_party.{}'.format(archive_ext)
+
 
 maybe_rebuild(KENLM_FILES, third_party_build, build_dir)
 maybe_rebuild(CTC_DECODER_FILES, ctc_decoder_build, build_dir)

--- a/native_client/ctcdecode/setup.py
+++ b/native_client/ctcdecode/setup.py
@@ -54,8 +54,12 @@ def maybe_rebuild(srcs, out_name, build_dir):
 project_version = read('../../VERSION').strip()
 
 build_dir = 'temp_build/temp_build'
-third_party_build = 'third_party.a'
-ctc_decoder_build = 'first_party.a'
+if sys.platform.startswith('win'):
+    third_party_build = 'third_party.lib'
+    ctc_decoder_build = 'first_party.lib'
+else:
+    third_party_build = 'third_party.a'
+    ctc_decoder_build = 'first_party.a'
 
 maybe_rebuild(KENLM_FILES, third_party_build, build_dir)
 maybe_rebuild(CTC_DECODER_FILES, ctc_decoder_build, build_dir)


### PR DESCRIPTION
This supports to build ctc_decoder wheel package on Windows system.

The package enable us to train models on Windows system.


My environments:

- Windows 10
- Visual Studio 2015
- Python 3.6
- Swig 3.0.12
- MSYS2


Build steps:

```
cd native_client\ctcdecode
set path=C:\msys64\usr\bin;%path%
set path=C:\ProgramData\swigwin-3.0.12;%path%
make TARGET=host-win
```
