### PR TITLE
Error early in generate_package.py if no alphabet was specified and not using UTF-8 mode

### DIFF
--- a/data/lm/generate_package.py
+++ b/data/lm/generate_package.py
@@ -48,6 +48,9 @@ def create_bundle(
     if use_utf8:
         serialized_alphabet = UTF8Alphabet().serialize()
     else:
+        if not alphabet_path:
+            print("No --alphabet path specified, can't continue.")
+            sys.exit(1)
         serialized_alphabet = Alphabet(alphabet_path).serialize()
 
     alphabet = NativeAlphabet()


### PR DESCRIPTION
https://discourse.mozilla.org/t/segmentation-fault-ctc-beam-search-decoder-batch-on-mac/56090/13