### PR TITLE
Refactor generate_package.py

### DIFF
--- a/data/lm/README.rst
+++ b/data/lm/README.rst
@@ -15,7 +15,7 @@ You can download the LibriSpeech corpus with the following commands:
 | As input you can use a plain text (e.g. ``file.txt``) or gzipped (e.g. ``file.txt.gz``) text file with one sentence in each line.
 |
 | If you are using the DeepSpeech docker container, you can use ``--kenlm_bins /DeepSpeech/native_client/kenlm/build/bin/``.
-| Else you have to build `KenLM <https://github.com/kpu/kenlm>`_ first and then pass the build directory to the script.
+ Else you have to build `KenLM <https://github.com/kpu/kenlm>`_ first and then pass the build directory to the script.
 
 .. code-block:: bash
 

--- a/data/lm/README.rst
+++ b/data/lm/README.rst
@@ -1,6 +1,6 @@
 | The LM binary was generated from the LibriSpeech normalized LM training text, available `here <http://www.openslr.org/11>`_.
 | It is created with `KenLM <https://github.com/kpu/kenlm>`_.
-
+|
 
 You can download the LibriSpeech corpus with the following commands:
 
@@ -11,8 +11,8 @@ You can download the LibriSpeech corpus with the following commands:
 
 | Then use the ``generate_lm.py`` script to generate ``lm.binary`` and ``vocab-500000.txt``.
 | As input you can use a plain text (e.g. ``file.txt``) or gzipped (e.g. ``file.txt.gz``) text file with one sentence in each line.
-
-If you are using a container created from the Dockerfile, you can use ``--kenlm_bins /DeepSpeech/native_client/kenlm/build/bin/``.
+|
+| If you are using a container created from the Dockerfile, you can use ``--kenlm_bins /DeepSpeech/native_client/kenlm/build/bin/``.
 Else you have to build `KenLM <https://github.com/kpu/kenlm>`_ first and then pass the build directory to the script.
 
 .. code-block:: bash

--- a/data/lm/README.rst
+++ b/data/lm/README.rst
@@ -1,6 +1,6 @@
-| The LM binary was generated from the LibriSpeech normalized LM training text, available `here <http://www.openslr.org/11>`_.
-| It is created with `KenLM <https://github.com/kpu/kenlm>`_.
-|
+The LM binary was generated from the LibriSpeech normalized LM training text, available `here <http://www.openslr.org/11>`_.
+It is created with `KenLM <https://github.com/kpu/kenlm>`_.
+
 
 You can download the LibriSpeech corpus with the following commands:
 
@@ -9,12 +9,12 @@ You can download the LibriSpeech corpus with the following commands:
     wget http://www.openslr.org/resources/11/librispeech-lm-norm.txt.gz
 
 
-| Then use the ``generate_lm.py`` script to generate ``lm.binary`` and ``vocab-500000.txt``.
-| As input you can use a plain text (e.g. ``file.txt``) or gzipped (e.g. ``file.txt.gz``) text file with one sentence in each line.
-|
-| If you are using a container created from the Dockerfile, you can use ``--kenlm_bins /DeepSpeech/native_client/kenlm/build/bin/``.
- Else you have to build `KenLM <https://github.com/kpu/kenlm>`_ first and then pass the build directory to the script.
-|
+Then use the ``generate_lm.py`` script to generate ``lm.binary`` and ``vocab-500000.txt``.
+
+As input you can use a plain text (e.g. ``file.txt``) or gzipped (e.g. ``file.txt.gz``) text file with one sentence in each line.
+
+If you are using a container created from the Dockerfile, you can use ``--kenlm_bins /DeepSpeech/native_client/kenlm/build/bin/``.
+Else you have to build `KenLM <https://github.com/kpu/kenlm>`_ first and then pass the build directory to the script.
 
 .. code-block:: bash
 

--- a/data/lm/README.rst
+++ b/data/lm/README.rst
@@ -1,5 +1,7 @@
-The LM binary was generated from the LibriSpeech normalized LM training text, available `here <http://www.openslr.org/11>`_.
-It is created with `KenLM <https://github.com/kpu/kenlm>`_.
+| The LM binary was generated from the LibriSpeech normalized LM training text, available `here <http://www.openslr.org/11>`_.
+| It is created with `KenLM <https://github.com/kpu/kenlm>`_.
+
+|
 
 You can download the LibriSpeech corpus with the following commands:
 
@@ -11,9 +13,9 @@ You can download the LibriSpeech corpus with the following commands:
 
 | Then use the ``generate_lm.py`` script to generate ``lm.binary`` and ``vocab-500000.txt``.
 | As input you can use a plain text (e.g. ``file.txt``) or gzipped (e.g. ``file.txt.gz``) text file with one sentence in each line.
-
-If you are using the DeepSpeech docker container, you can use ``--kenlm_bins /DeepSpeech/native_client/kenlm/build/bin/``.
-Else you have to build `KenLM <https://github.com/kpu/kenlm>`_ first and then pass the build directory to the script.
+|
+| If you are using the DeepSpeech docker container, you can use ``--kenlm_bins /DeepSpeech/native_client/kenlm/build/bin/``.
+| Else you have to build `KenLM <https://github.com/kpu/kenlm>`_ first and then pass the build directory to the script.
 
 .. code-block:: bash
 

--- a/data/lm/README.rst
+++ b/data/lm/README.rst
@@ -1,7 +1,6 @@
 | The LM binary was generated from the LibriSpeech normalized LM training text, available `here <http://www.openslr.org/11>`_.
 | It is created with `KenLM <https://github.com/kpu/kenlm>`_.
 
-|
 
 You can download the LibriSpeech corpus with the following commands:
 
@@ -9,13 +8,12 @@ You can download the LibriSpeech corpus with the following commands:
 
     wget http://www.openslr.org/resources/11/librispeech-lm-norm.txt.gz
 
-|
 
 | Then use the ``generate_lm.py`` script to generate ``lm.binary`` and ``vocab-500000.txt``.
 | As input you can use a plain text (e.g. ``file.txt``) or gzipped (e.g. ``file.txt.gz``) text file with one sentence in each line.
-|
-| If you are using a container created from the Dockerfile, you can use ``--kenlm_bins /DeepSpeech/native_client/kenlm/build/bin/``.
- Else you have to build `KenLM <https://github.com/kpu/kenlm>`_ first and then pass the build directory to the script.
+
+If you are using a container created from the Dockerfile, you can use ``--kenlm_bins /DeepSpeech/native_client/kenlm/build/bin/``.
+Else you have to build `KenLM <https://github.com/kpu/kenlm>`_ first and then pass the build directory to the script.
 
 .. code-block:: bash
 
@@ -24,7 +22,6 @@ You can download the LibriSpeech corpus with the following commands:
       --arpa_order 5 --max_arpa_memory "85%" --arpa_prune "0|0|1" \
       --binary_a_bits 255 --binary_q_bits 8 --binary_type trie
 
-|
 
 Afterwards you can use ``generate_package.py`` to generate the scorer package using the ``lm.binary`` and ``vocab-500000.txt`` files:
 

--- a/data/lm/README.rst
+++ b/data/lm/README.rst
@@ -16,8 +16,8 @@ If you are not using the DeepSpeech docker container, you have to build `KenLM <
 
 .. code-block:: bash
 
-    python3 data/lm/generate_lm.py --input_txt librispeech-lm-norm.txt.gz \
-      --output_dir . --top_k 500000 --kenlm_bins path/to/kenlm/build/bin/ \
+    python3 generate_lm.py --input_txt librispeech-lm-norm.txt.gz --output_dir . \
+      --top_k 500000 --kenlm_bins /DeepSpeech/native_client/kenlm/build/bin/ \
       --arpa_order 5 --max_arpa_memory "85%" --arpa_prune "0|0|1" \
       --binary_a_bits 255 --binary_q_bits 8 --binary_type trie
 

--- a/data/lm/README.rst
+++ b/data/lm/README.rst
@@ -14,7 +14,7 @@ You can download the LibriSpeech corpus with the following commands:
 | Then use the ``generate_lm.py`` script to generate ``lm.binary`` and ``vocab-500000.txt``.
 | As input you can use a plain text (e.g. ``file.txt``) or gzipped (e.g. ``file.txt.gz``) text file with one sentence in each line.
 |
-| If you are using the DeepSpeech docker container, you can use ``--kenlm_bins /DeepSpeech/native_client/kenlm/build/bin/``.
+| If you are using a container created from the Dockerfile, you can use ``--kenlm_bins /DeepSpeech/native_client/kenlm/build/bin/``.
  Else you have to build `KenLM <https://github.com/kpu/kenlm>`_ first and then pass the build directory to the script.
 
 .. code-block:: bash

--- a/data/lm/README.rst
+++ b/data/lm/README.rst
@@ -13,7 +13,7 @@ You can download the LibriSpeech corpus with the following commands:
 | As input you can use a plain text (e.g. ``file.txt``) or gzipped (e.g. ``file.txt.gz``) text file with one sentence in each line.
 |
 | If you are using a container created from the Dockerfile, you can use ``--kenlm_bins /DeepSpeech/native_client/kenlm/build/bin/``.
-Else you have to build `KenLM <https://github.com/kpu/kenlm>`_ first and then pass the build directory to the script.
+ Else you have to build `KenLM <https://github.com/kpu/kenlm>`_ first and then pass the build directory to the script.
 
 .. code-block:: bash
 

--- a/data/lm/README.rst
+++ b/data/lm/README.rst
@@ -7,22 +7,24 @@ You can download the LibriSpeech corpus with the following commands:
 
     wget http://www.openslr.org/resources/11/librispeech-lm-norm.txt.gz
 
+|
 
-Then use the `generate_lm.py` script to generate `lm.binary` and `vocab-500000.txt`.
+| Then use the ``generate_lm.py`` script to generate ``lm.binary`` and ``vocab-500000.txt``.
+| As input you can use a plain text (e.g. ``file.txt``) or gzipped (e.g. ``file.txt.gz``) text file with one sentence in each line.
 
-As input you can use a plain text (e.g. `file.txt`) or gzipped (e.g. `file.txt.gz`) text file with one sentence in each line.
-
-If you are not using the DeepSpeech docker container, you have to build `KenLM <https://github.com/kpu/kenlm>`_ first and then pass the build directory to the script.
+If you are using the DeepSpeech docker container, you can use ``--kenlm_bins /DeepSpeech/native_client/kenlm/build/bin/``.
+Else you have to build `KenLM <https://github.com/kpu/kenlm>`_ first and then pass the build directory to the script.
 
 .. code-block:: bash
 
     python3 generate_lm.py --input_txt librispeech-lm-norm.txt.gz --output_dir . \
-      --top_k 500000 --kenlm_bins /DeepSpeech/native_client/kenlm/build/bin/ \
+      --top_k 500000 --kenlm_bins path/to/kenlm/build/bin/ \
       --arpa_order 5 --max_arpa_memory "85%" --arpa_prune "0|0|1" \
       --binary_a_bits 255 --binary_q_bits 8 --binary_type trie
 
+|
 
-Afterwards you can use `generate_package.py` to generate the scorer package using the lm.binary and vocab-500000.txt files:
+Afterwards you can use ``generate_package.py`` to generate the scorer package using the ``lm.binary`` and ``vocab-500000.txt`` files:
 
 .. code-block:: bash
 

--- a/data/lm/README.rst
+++ b/data/lm/README.rst
@@ -14,6 +14,7 @@ You can download the LibriSpeech corpus with the following commands:
 |
 | If you are using a container created from the Dockerfile, you can use ``--kenlm_bins /DeepSpeech/native_client/kenlm/build/bin/``.
  Else you have to build `KenLM <https://github.com/kpu/kenlm>`_ first and then pass the build directory to the script.
+|
 
 .. code-block:: bash
 

--- a/data/lm/generate_package.py
+++ b/data/lm/generate_package.py
@@ -30,13 +30,11 @@ def create_bundle(
     cbm = "Looks" if vocab_looks_char_based else "Doesn't look"
     print("{} like a character based model.".format(cbm))
 
-    if force_utf8 in ("True", "1", "true", "yes", "y"):
-        use_utf8 = True
-    elif force_utf8 in ("False", "0", "false", "no", "n"):
-        use_utf8 = False
-    else:
+    if force_utf8 is None:
         use_utf8 = vocab_looks_char_based
         print("Using detected UTF-8 mode: {}".format(use_utf8))
+    else:
+        use_utf8 = force_utf8
 
     if use_utf8:
         serialized_alphabet = UTF8Alphabet().serialize()
@@ -100,12 +98,19 @@ def main():
     )
     args = parser.parse_args()
 
+    if args.force_utf8 in ("True", "1", "true", "yes", "y"):
+        force_utf8 = True
+    elif args.force_utf8 in ("False", "0", "false", "no", "n"):
+        force_utf8 = False
+    else:
+        force_utf8 = None
+
     create_bundle(
         args.alphabet,
         args.lm,
         args.vocab,
         args.package,
-        args.force_utf8,
+        force_utf8,
         args.default_alpha,
         args.default_beta,
     )

--- a/data/lm/generate_package.py
+++ b/data/lm/generate_package.py
@@ -30,11 +30,12 @@ def create_bundle(
     cbm = "Looks" if vocab_looks_char_based else "Doesn't look"
     print("{} like a character based model.".format(cbm))
 
-    if force_utf8 is None:
+    if force_utf8 is True or force_utf8 is False:
+        use_utf8 = force_utf8
+    else:
+        # Use detected utf-8 mode for everything except True/False boolean values
         use_utf8 = vocab_looks_char_based
         print("Using detected UTF-8 mode: {}".format(use_utf8))
-    else:
-        use_utf8 = force_utf8
 
     if use_utf8:
         serialized_alphabet = UTF8Alphabet().serialize()

--- a/data/lm/generate_package.py
+++ b/data/lm/generate_package.py
@@ -30,10 +30,9 @@ def create_bundle(
     cbm = "Looks" if vocab_looks_char_based else "Doesn't look"
     print("{} like a character based model.".format(cbm))
 
-    if force_utf8 is True or force_utf8 is False:
+    if force_utf8 != None:  # pylint: disable=singleton-comparison
         use_utf8 = force_utf8
     else:
-        # Use detected utf-8 mode for everything except True/False boolean values
         use_utf8 = vocab_looks_char_based
         print("Using detected UTF-8 mode: {}".format(use_utf8))
 
@@ -58,6 +57,33 @@ def create_bundle(
     shutil.copy(lm_path, package_path)
     scorer.save_dictionary(package_path, True)  # append, not overwrite
     print("Package created in {}".format(package_path))
+
+
+class Tristate(object):
+    def __init__(self, value=None):
+        if any(value is v for v in (True, False, None)):
+            self.value = value
+        else:
+            raise ValueError("Tristate value must be True, False, or None")
+
+    def __eq__(self, other):
+        return (
+            self.value is other.value
+            if isinstance(other, Tristate)
+            else self.value is other
+        )
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __bool__(self):
+        raise TypeError("Tristate object may not be used as a Boolean")
+
+    def __str__(self):
+        return str(self.value)
+
+    def __repr__(self):
+        return "Tristate(%s)" % self.value
 
 
 def main():
@@ -100,11 +126,11 @@ def main():
     args = parser.parse_args()
 
     if args.force_utf8 in ("True", "1", "true", "yes", "y"):
-        force_utf8 = True
+        force_utf8 = Tristate(True)
     elif args.force_utf8 in ("False", "0", "false", "no", "n"):
-        force_utf8 = False
+        force_utf8 = Tristate(False)
     else:
-        force_utf8 = None
+        force_utf8 = Tristate(None)
 
     create_bundle(
         args.alphabet,

--- a/data/lm/generate_package.py
+++ b/data/lm/generate_package.py
@@ -31,7 +31,7 @@ def create_bundle(
     print("{} like a character based model.".format(cbm))
 
     if force_utf8 != None:  # pylint: disable=singleton-comparison
-        use_utf8 = force_utf8
+        use_utf8 = force_utf8.value
     else:
         use_utf8 = vocab_looks_char_based
         print("Using detected UTF-8 mode: {}".format(use_utf8))

--- a/data/lm/generate_package.py
+++ b/data/lm/generate_package.py
@@ -94,6 +94,7 @@ def main():
     )
     parser.add_argument(
         "--force_utf8",
+        type=str,
         default="",
         help="Boolean flag, force set or unset UTF-8 mode in the scorer package. If not set, infers from the vocabulary. See <https://github.com/mozilla/DeepSpeech/blob/master/doc/Decoder.rst#utf-8-mode> for further explanation",
     )


### PR DESCRIPTION
Removed tristate class for better readability.

Also updated `--kenlm_bins` parameter to use path from docker container, that users don't have to search for the installation path.