### PR TITLE
Documentation Suggestion: native_client can be found in the releases

### DIFF
--- a/doc/USING.rst
+++ b/doc/USING.rst
@@ -160,6 +160,8 @@ also, if you need some binaries different than current master, like ``v0.2.0-alp
 
 The script ``taskcluster.py`` will download ``native_client.tar.xz`` (which includes the ``deepspeech`` binary and associated libraries) and extract it into the current folder. Also, ``taskcluster.py`` will download binaries for Linux/x86_64 by default, but you can override that behavior with the ``--arch`` parameter. See the help info with ``python util/taskcluster.py -h`` for more details. Specific branches of DeepSpeech or TensorFlow can be specified as well.
 
+Alternatively you may manually download the ``native_client.tar.xz`` from the [releases](https://github.com/mozilla/DeepSpeech/releases).
+
 Note: the following command assumes you `downloaded the pre-trained model <#getting-the-pre-trained-model>`_.
 
 .. code-block:: bash


### PR DESCRIPTION
I wanted to install the binary without cloning the entire repository (and thereby the required `util/taskcluster.py`) and was only able to find it pretty much by chance. I feel that adding this into the README could save people from a few headaches.