### PR TITLE
Ugly, very ugly, incredibly ugly static linking of libsox on macOS

### DIFF
--- a/native_client/Makefile
+++ b/native_client/Makefile
@@ -18,10 +18,9 @@ default: $(DEEPSPEECH_BIN)
 clean:
 	rm -f deepspeech
 
-$(DEEPSPEECH_BIN): client.cc
+$(DEEPSPEECH_BIN): client.cc Makefile
 	$(CXX) $(CFLAGS) $(CFLAGS_DEEPSPEECH) $(SOX_CFLAGS) client.cc $(LDFLAGS) $(SOX_LDFLAGS)
 ifeq ($(OS),Darwin)
-	install_name_tool -change $$TASKCLUSTER_TASK_DIR/homebrew-builds/opt/sox/lib/libsox.3.dylib @rpath/libsox.3.dylib deepspeech
 	install_name_tool -change bazel-out/local-opt/bin/native_client/libdeepspeech.so @rpath/libdeepspeech.so deepspeech
 endif
 


### PR DESCRIPTION
All of the brew installed dependencies have static libraries as well, but the macOS linker will always prefer a dynamic library if both exist under the same `-L/foo -lbar` resolution. The only way to force static linking is to include a full path to the static library. These changes basically reverse engineer the static library locations and then pass those to the linker.