### PR TITLE
Fix JS IntermediateDecodeWithMetadata binding

### DIFF
--- a/native_client/javascript/index.js
+++ b/native_client/javascript/index.js
@@ -184,7 +184,7 @@ Stream.prototype.intermediateDecode = function() {
  */
 Stream.prototype.intermediateDecodeWithMetadata = function(aNumResults) {
     aNumResults = aNumResults || 1;
-    return binding.IntermediateDecode(this._impl, aNumResults);
+    return binding.IntermediateDecodeWithMetadata(this._impl, aNumResults);
 }
 
 /**


### PR DESCRIPTION
The Node.js binding for `stream.intermediateDecodeWithMetadata()` was calling `binding.IntermediateDecode()` instead of `binding.IntermediateDecodeWithMetadata()` which would always cause the error:
```
Illegal number of arguments for _wrap_IntermediateDecode
```
Verified that this works as expected after the fix.