### PR TITLE
Fix arguments order in pcm_to_np call

### DIFF
--- a/training/deepspeech_training/util/feeding.py
+++ b/training/deepspeech_training/util/feeding.py
@@ -168,7 +168,7 @@ def split_audio_file(audio_path,
         segments = vad_split(frames, aggressiveness=aggressiveness)
         for segment in segments:
             segment_buffer, time_start, time_end = segment
-            samples = pcm_to_np(audio_format, segment_buffer)
+            samples = pcm_to_np(segment_buffer, audio_format)
             yield time_start, time_end, samples
 
     def to_mfccs(time_start, time_end, samples):


### PR DESCRIPTION
pcm_to_np takes segment buffer as its first argument and audio format as a second one. The wrong order cause "bytes object has no attribute 'channels'' ArgumentError.