### PR TITLE
Added third-party bindings for NIM-lang.

### DIFF
--- a/doc/USING.rst
+++ b/doc/USING.rst
@@ -213,4 +213,4 @@ In addition to the bindings above, third party developers have started to provid
 * `stes <https://github.com/stes>`_ provides preliminary `PKGBUILDs <https://wiki.archlinux.org/index.php/PKGBUILD>`_ to install the client and python bindings on `Arch Linux <https://www.archlinux.org/>`_ in the `arch-deepspeech <https://github.com/stes/arch-deepspeech>`_ repo.
 * `gst-deepspeech <https://github.com/Elleo/gst-deepspeech>`_ provides a `GStreamer <https://gstreamer.freedesktop.org/>`_ plugin which can be used from any language with GStreamer bindings.
 * `thecodrr <https://github.com/thecodrr>`_ provides `Vlang <https://vlang.io>`_ bindings. The installation and use of which is described in their `vspeech <https://github.com/thecodrr/vspeech>`_ repo.
-
+* `eagledot <https://gitlab.com/eagledot>`_ provides `NIM-lang <https://nim-lang.org/>`_ bindings. The installation and use of which is described in their `nim-deepspeech <https://gitlab.com/eagledot/nim-deepspeech>`_ repo.


### PR DESCRIPTION
Hello there.
I have added DeepSpeech bindings for [nim-lang](https://nim-lang.org) and wanted to add it into the 3rd Party Bindings list.

I am using `git tags` starting with DeepSpeech's version `0.7.x`  and  hoping to use tag system for handling changes/breakage in upcoming API.