### PR TITLE
The CTC decoder timesteps now corresponds to the timesteps of the most probable CTC path, instead of the earliest timesteps of all possible paths.

### DIFF
--- a/native_client/BUILD
+++ b/native_client/BUILD
@@ -100,6 +100,7 @@ cc_library(
     includes = [
         ".",
         "ctcdecode/third_party/ThreadPool",
+        "ctcdecode/third_party/object_pool",
     ] + OPENFST_INCLUDES_PLATFORM,
     deps = [":kenlm"],
     linkopts = [

--- a/native_client/ctcdecode/build_archive.py
+++ b/native_client/ctcdecode/build_archive.py
@@ -26,7 +26,8 @@ INCLUDES = [
     '..',
     '../kenlm',
     OPENFST_DIR + '/src/include',
-    'third_party/ThreadPool'
+    'third_party/ThreadPool',
+    'third_party/object_pool'
 ]
 
 KENLM_FILES = (glob.glob('../kenlm/util/*.cc')

--- a/native_client/ctcdecode/ctc_beam_search_decoder.cpp
+++ b/native_client/ctcdecode/ctc_beam_search_decoder.cpp
@@ -232,7 +232,7 @@ DecoderState::decode(size_t num_results) const
 
   for (PathTrie* prefix : prefixes_copy) {
     Output output;
-    output.tokens     = prefix->get_path_vec();
+    prefix->get_path_vec(output.tokens);
     output.timesteps  = prefix->timesteps;
     output.confidence = scores[prefix];
     outputs.push_back(output);

--- a/native_client/ctcdecode/ctc_beam_search_decoder.cpp
+++ b/native_client/ctcdecode/ctc_beam_search_decoder.cpp
@@ -99,22 +99,22 @@ DecoderState::next(const double *probs,
         if (prefix->score == -NUM_FLT_INF) {
           continue;
         }
-		if (!prefix->is_empty() && prefix->timesteps.empty()) {
-		  // This should never happen. But we report it if it does.
-		  std::cerr<<"error: non-empty prefix has empty timestep sequence"<<std::endl;
-		  continue;
-		}
+        if (!prefix->is_empty() && prefix->timesteps.empty()) {
+          // This should never happen. But we report it if it does.
+          std::cerr<<"error: non-empty prefix has empty timestep sequence"<<std::endl;
+          continue;
+        }
 
         // blank
         if (c == blank_id_) {
-		  // compute probability of current path
+          // compute probability of current path
           float log_p = log_prob_c + prefix->score;
 
-		  // combine current path with previous ones with the same prefix
-		  // the blank label comes last, so we can compare log_prob_nb_cur with log_p
-		  if (prefix->log_prob_nb_cur < log_p) {
-			  prefix->timesteps_cur = prefix->timesteps;
-		  }
+          // combine current path with previous ones with the same prefix
+          // the blank label comes last, so we can compare log_prob_nb_cur with log_p
+          if (prefix->log_prob_nb_cur < log_p) {
+              prefix->timesteps_cur = prefix->timesteps;
+          }
           prefix->log_prob_b_cur =
               log_sum_exp(prefix->log_prob_b_cur, log_p);
           continue;
@@ -122,10 +122,10 @@ DecoderState::next(const double *probs,
 
         // repeated character
         if (c == prefix->character) {
-		  // compute probability of current path
+          // compute probability of current path
           float log_p = log_prob_c + prefix->log_prob_nb_prev;
 
-		  // combine current path with previous ones with the same prefix
+          // combine current path with previous ones with the same prefix
           if (prefix->log_prob_nb_cur < log_p) {
               prefix->timesteps_cur = prefix->timesteps;
           }
@@ -137,11 +137,11 @@ DecoderState::next(const double *probs,
         auto prefix_new = prefix->get_path_trie(c, log_prob_c);
 
         if (prefix_new != nullptr) {
-		  // compute timesteps of current path
-		  std::vector<unsigned int> timesteps_new=prefix->timesteps;
-		  timesteps_new.push_back(abs_time_step_);
+          // compute timesteps of current path
+          std::vector<unsigned int> timesteps_new=prefix->timesteps;
+          timesteps_new.push_back(abs_time_step_);
 
-		  // compute probability of current path
+          // compute probability of current path
           float log_p = -NUM_FLT_INF;
 
           if (c == prefix->character &&
@@ -172,7 +172,7 @@ DecoderState::next(const double *probs,
             }
           }
 
-		  // combine current path with previous ones with the same prefix
+          // combine current path with previous ones with the same prefix
           if (prefix_new->log_prob_nb_cur < log_p) {
               prefix_new->timesteps_cur = timesteps_new;
           }
@@ -240,10 +240,10 @@ DecoderState::decode(size_t num_results) const
   for (PathTrie* prefix : prefixes_copy) {
     Output output;
     output.tokens     = prefix->get_path_vec();
-	output.timesteps  = prefix->timesteps;
+    output.timesteps  = prefix->timesteps;
     output.confidence = scores[prefix];
     outputs.push_back(output);
-	if(outputs.size()>=num_returned) break;
+    if(outputs.size()>=num_returned) break;
   }
 
   return outputs;

--- a/native_client/ctcdecode/ctc_beam_search_decoder.cpp
+++ b/native_client/ctcdecode/ctc_beam_search_decoder.cpp
@@ -96,6 +96,9 @@ DecoderState::next(const double *probs,
         if (full_beam && log_prob_c + prefix->score < min_cutoff) {
           break;
         }
+        if (prefix->score == -NUM_FLT_INF) {
+          continue;
+        }
         assert(prefix->is_empty() || prefix->timesteps != nullptr);
 
         // blank

--- a/native_client/ctcdecode/ctc_beam_search_decoder.cpp
+++ b/native_client/ctcdecode/ctc_beam_search_decoder.cpp
@@ -96,11 +96,7 @@ DecoderState::next(const double *probs,
         if (full_beam && log_prob_c + prefix->score < min_cutoff) {
           break;
         }
-        if (!prefix->is_empty() && prefix->timesteps.empty()) {
-          // This should never happen. But we report it if it does.
-          std::cerr<<"error: non-empty prefix has empty timestep sequence"<<std::endl;
-          continue;
-        }
+        assert(prefix->is_empty() || !prefix->timesteps.empty());
 
         // blank
         if (c == blank_id_) {

--- a/native_client/ctcdecode/ctc_beam_search_decoder.cpp
+++ b/native_client/ctcdecode/ctc_beam_search_decoder.cpp
@@ -235,14 +235,13 @@ DecoderState::decode(size_t num_results) const
   std::vector<Output> outputs;
   outputs.reserve(num_returned);
 
-  for (PathTrie* prefix : prefixes_copy) {
+  for (size_t i = 0; i < num_returned; ++i) {
     Output output;
-    prefix->get_path_vec(output.tokens);
-    output.timesteps  = get_history(prefix->timesteps, &timestep_tree_root_);
+    prefixes_copy[i]->get_path_vec(output.tokens);
+    output.timesteps  = get_history(prefixes_copy[i]->timesteps, &timestep_tree_root_);
     assert(output.tokens.size() == output.timesteps.size());
-    output.confidence = scores[prefix];
+    output.confidence = scores[prefixes_copy[i]];
     outputs.push_back(output);
-    if (outputs.size() >= num_returned) break;
   }
 
   return outputs;

--- a/native_client/ctcdecode/ctc_beam_search_decoder.cpp
+++ b/native_client/ctcdecode/ctc_beam_search_decoder.cpp
@@ -37,7 +37,7 @@ DecoderState::init(const Alphabet& alphabet,
   prefix_root_.reset(root);
   prefix_root_->timesteps = &timestep_tree_root_;
   prefixes_.push_back(root);
-  
+
   if (ext_scorer && (bool)(ext_scorer_->dictionary)) {
     // no need for std::make_shared<>() since Copy() does 'new' behind the doors
     auto dict_ptr = std::shared_ptr<PathTrie::FstType>(ext_scorer->dictionary->Copy(true));

--- a/native_client/ctcdecode/ctc_beam_search_decoder.cpp
+++ b/native_client/ctcdecode/ctc_beam_search_decoder.cpp
@@ -96,9 +96,6 @@ DecoderState::next(const double *probs,
         if (full_beam && log_prob_c + prefix->score < min_cutoff) {
           break;
         }
-        if (prefix->score == -NUM_FLT_INF) {
-          continue;
-        }
         if (!prefix->is_empty() && prefix->timesteps.empty()) {
           // This should never happen. But we report it if it does.
           std::cerr<<"error: non-empty prefix has empty timestep sequence"<<std::endl;

--- a/native_client/ctcdecode/ctc_beam_search_decoder.cpp
+++ b/native_client/ctcdecode/ctc_beam_search_decoder.cpp
@@ -37,8 +37,6 @@ DecoderState::init(const Alphabet& alphabet,
   prefix_root_.reset(root);
   prefixes_.push_back(root);
   
-  timestep_tree_root_=std::make_shared<TimestepTreeNode>(nullptr, 0);
-
   if (ext_scorer && (bool)(ext_scorer_->dictionary)) {
     // no need for std::make_shared<>() since Copy() does 'new' behind the doors
     auto dict_ptr = std::shared_ptr<PathTrie::FstType>(ext_scorer->dictionary->Copy(true));
@@ -183,7 +181,7 @@ DecoderState::next(const double *probs,
     prefix_root_->iterate_to_vec(prefixes_);
     if (abs_time_step_ == 0) {
       for (PathTrie* prefix:prefixes_) {
-        prefix->timesteps = timestep_tree_root_;
+        prefix->timesteps = &timestep_tree_root_;
       }
     }
 

--- a/native_client/ctcdecode/ctc_beam_search_decoder.cpp
+++ b/native_client/ctcdecode/ctc_beam_search_decoder.cpp
@@ -96,7 +96,7 @@ DecoderState::next(const double *probs,
         if (full_beam && log_prob_c + prefix->score < min_cutoff) {
           break;
         }
-        assert(prefix->is_empty() || prefix->timesteps!=nullptr);
+        assert(prefix->is_empty() || prefix->timesteps != nullptr);
 
         // blank
         if (c == blank_id_) {
@@ -242,7 +242,7 @@ DecoderState::decode(size_t num_results) const
     output.timesteps  = get_history(prefix->timesteps);
     output.confidence = scores[prefix];
     outputs.push_back(output);
-    if(outputs.size()>=num_returned) break;
+    if (outputs.size() >= num_returned) break;
   }
 
   return outputs;

--- a/native_client/ctcdecode/ctc_beam_search_decoder.h
+++ b/native_client/ctcdecode/ctc_beam_search_decoder.h
@@ -21,7 +21,7 @@ class DecoderState {
   std::shared_ptr<Scorer> ext_scorer_;
   std::vector<PathTrie*> prefixes_;
   std::unique_ptr<PathTrie> prefix_root_;
-  std::shared_ptr<TimestepTreeNode> timestep_tree_root_;
+  TimestepTreeNode timestep_tree_root_{nullptr, 0};
 
 public:
   DecoderState() = default;

--- a/native_client/ctcdecode/ctc_beam_search_decoder.h
+++ b/native_client/ctcdecode/ctc_beam_search_decoder.h
@@ -21,6 +21,7 @@ class DecoderState {
   std::shared_ptr<Scorer> ext_scorer_;
   std::vector<PathTrie*> prefixes_;
   std::unique_ptr<PathTrie> prefix_root_;
+  std::shared_ptr<TimestepTreeNode> timestep_tree_root_;
 
 public:
   DecoderState() = default;

--- a/native_client/ctcdecode/path_trie.cpp
+++ b/native_client/ctcdecode/path_trie.cpp
@@ -99,15 +99,13 @@ PathTrie* PathTrie::get_path_trie(unsigned int new_char, float cur_log_prob_c, b
   }
 }
 
-std::vector<unsigned int> PathTrie::get_path_vec() {
-  if (parent == nullptr) {
-    return std::vector<unsigned int>{};
+void PathTrie::get_path_vec(std::vector<unsigned int>& output) {
+  // Recursive call: recurse back until stop condition, then append data in
+  // correct order as we walk back down the stack in the lines below.
+  if (parent != nullptr) {
+    parent->get_path_vec(output);
+    output.push_back(character);
   }
-  std::vector<unsigned int> output_tokens=parent->get_path_vec();
-  if (character != ROOT_) {
-      output_tokens.push_back(character);
-  }
-  return output_tokens;
 }
 
 PathTrie* PathTrie::get_prev_grapheme(std::vector<unsigned int>& output,

--- a/native_client/ctcdecode/path_trie.cpp
+++ b/native_client/ctcdecode/path_trie.cpp
@@ -101,11 +101,11 @@ PathTrie* PathTrie::get_path_trie(unsigned int new_char, float cur_log_prob_c, b
 
 std::vector<unsigned int> PathTrie::get_path_vec() {
   if (parent == nullptr) {
-	return std::vector<unsigned int>{};
+    return std::vector<unsigned int>{};
   }
   std::vector<unsigned int> output_tokens=parent->get_path_vec();
   if (character != ROOT_) {
-  	output_tokens.push_back(character);
+      output_tokens.push_back(character);
   }
   return output_tokens;
 }
@@ -166,8 +166,8 @@ void PathTrie::iterate_to_vec(std::vector<PathTrie*>& output) {
 
     score = log_sum_exp(log_prob_b_prev, log_prob_nb_prev);
 
-	timesteps = std::move(timesteps_cur);
-	timesteps_cur.clear();
+    timesteps = std::move(timesteps_cur);
+    timesteps_cur.clear();
 
     output.push_back(this);
   }

--- a/native_client/ctcdecode/path_trie.cpp
+++ b/native_client/ctcdecode/path_trie.cpp
@@ -179,11 +179,11 @@ void PathTrie::iterate_to_vec(std::vector<PathTrie*>& output) {
             break;
         }
       }
-      if (timesteps == nullptr){
+      if (timesteps == nullptr) {
           timesteps = add_child(previous_timesteps, new_timestep);
       }
     }
-    previous_timesteps=nullptr;
+    previous_timesteps = nullptr;
 
     output.push_back(this);
   }

--- a/native_client/ctcdecode/path_trie.cpp
+++ b/native_client/ctcdecode/path_trie.cpp
@@ -175,7 +175,7 @@ void PathTrie::iterate_to_vec(std::vector<PathTrie*>& output) {
       timesteps = nullptr;
       for (auto const& child : previous_timesteps->children) {
         if (child->data == new_timestep) {
-            timesteps=child;
+            timesteps = child.get();
             break;
         }
       }

--- a/native_client/ctcdecode/path_trie.cpp
+++ b/native_client/ctcdecode/path_trie.cpp
@@ -172,8 +172,16 @@ void PathTrie::iterate_to_vec(std::vector<PathTrie*>& output) {
     score = log_sum_exp(log_prob_b_prev, log_prob_nb_prev);
 
     if (previous_timesteps != nullptr) {
-      timesteps = *previous_timesteps;
-      timesteps.push_back(new_timestep);
+      timesteps = nullptr;
+      for (auto const& child : previous_timesteps->children) {
+        if (child->data == new_timestep) {
+            timesteps=child;
+            break;
+        }
+      }
+      if (timesteps == nullptr){
+          timesteps = add_child(previous_timesteps, new_timestep);
+      }
     }
     previous_timesteps=nullptr;
 
@@ -230,7 +238,7 @@ void PathTrie::print(const Alphabet& a) {
     }
   }
   printf("\ntimesteps:\t ");
-  for (unsigned int timestep : timesteps) {
+  for (unsigned int timestep : get_history(timesteps)) {
     printf("%d ", timestep);
   }
   printf("\n");

--- a/native_client/ctcdecode/path_trie.cpp
+++ b/native_client/ctcdecode/path_trie.cpp
@@ -104,6 +104,8 @@ void PathTrie::get_path_vec(std::vector<unsigned int>& output) {
   // correct order as we walk back down the stack in the lines below.
   if (parent != nullptr) {
     parent->get_path_vec(output);
+  }
+  if (character != ROOT_) {
     output.push_back(character);
   }
 }

--- a/native_client/ctcdecode/path_trie.cpp
+++ b/native_client/ctcdecode/path_trie.cpp
@@ -157,6 +157,11 @@ PathTrie* PathTrie::get_prev_word(std::vector<unsigned int>& output,
 }
 
 void PathTrie::iterate_to_vec(std::vector<PathTrie*>& output) {
+  // previous_timesteps might point to ancestors' timesteps
+  // therefore, children must be uptaded first
+  for (auto child : children_) {
+    child.second->iterate_to_vec(output);
+  }
   if (exists_) {
     log_prob_b_prev = log_prob_b_cur;
     log_prob_nb_prev = log_prob_nb_cur;
@@ -166,13 +171,13 @@ void PathTrie::iterate_to_vec(std::vector<PathTrie*>& output) {
 
     score = log_sum_exp(log_prob_b_prev, log_prob_nb_prev);
 
-    timesteps = std::move(timesteps_cur);
-    timesteps_cur.clear();
+    if (previous_timesteps != nullptr) {
+      timesteps = *previous_timesteps;
+      timesteps.push_back(new_timestep);
+    }
+    previous_timesteps=nullptr;
 
     output.push_back(this);
-  }
-  for (auto child : children_) {
-    child.second->iterate_to_vec(output);
   }
 }
 

--- a/native_client/ctcdecode/path_trie.h
+++ b/native_client/ctcdecode/path_trie.h
@@ -109,7 +109,7 @@ private:
 // TreeNode implementation
 template<class NodeDataT, class ChildDataT>
 TreeNode<NodeDataT>* add_child(TreeNode<NodeDataT>* node, ChildDataT&& data_) {
-    static godefv::memory::object_pool_t<TreeNode<NodeDataT>> tree_node_pool;
+    static thread_local godefv::memory::object_pool_t<TreeNode<NodeDataT>> tree_node_pool;
     node->children.push_back(tree_node_pool.make_unique(node, std::forward<ChildDataT>(data_)));
     return node->children.back().get();
 }

--- a/native_client/ctcdecode/path_trie.h
+++ b/native_client/ctcdecode/path_trie.h
@@ -28,7 +28,7 @@ template<class NodeDataT, class ChildDataT>
 TreeNode<NodeDataT>* add_child(TreeNode<NodeDataT>* node, ChildDataT&& data_);
 
 template<class DataT>
-std::vector<DataT> get_history(TreeNode<DataT>*);
+std::vector<DataT> get_history(TreeNode<DataT> const*, TreeNode<DataT> const* = nullptr);
 
 using TimestepTreeNode = TreeNode<unsigned int>;
 
@@ -115,16 +115,17 @@ TreeNode<NodeDataT>* add_child(TreeNode<NodeDataT>* node, ChildDataT&& data_) {
 }
 
 template<class DataT>
-void get_history_helper(TreeNode<DataT>* tree_node, std::vector<DataT>* output) {
-    if (tree_node == nullptr) return;
+void get_history_helper(TreeNode<DataT> const* tree_node, TreeNode<DataT> const* root, std::vector<DataT>* output) {
+    if (tree_node == root) return;
+    assert(tree_node != nullptr);
     assert(tree_node->parent != tree_node);
-    get_history_helper(tree_node->parent, output);
+    get_history_helper(tree_node->parent, root, output);
     output->push_back(tree_node->data);
 }
 template<class DataT>
-std::vector<DataT> get_history(TreeNode<DataT>* tree_node) {
+std::vector<DataT> get_history(TreeNode<DataT> const* tree_node, TreeNode<DataT> const* root) {
     std::vector<DataT> output;
-    get_history_helper(tree_node, &output);
+    get_history_helper(tree_node, root, &output);
     return output;
 }
 

--- a/native_client/ctcdecode/path_trie.h
+++ b/native_client/ctcdecode/path_trie.h
@@ -21,14 +21,13 @@ public:
   ~PathTrie();
 
   // get new prefix after appending new char
-  PathTrie* get_path_trie(unsigned int new_char, unsigned int new_timestep, float log_prob_c, bool reset = true);
+  PathTrie* get_path_trie(unsigned int new_char, float log_prob_c, bool reset = true);
 
   // get the prefix data in correct time order from root to current node
-  void get_path_vec(std::vector<unsigned int>& output, std::vector<unsigned int>& timesteps);
+  std::vector<unsigned int> get_path_vec();
 
   // get the prefix data in correct time order from beginning of last grapheme to current node
   PathTrie* get_prev_grapheme(std::vector<unsigned int>& output,
-                              std::vector<unsigned int>& timesteps,
                               const Alphabet& alphabet);
 
   // get the distance from current node to the first codepoint boundary, and the byte value at the boundary
@@ -36,7 +35,6 @@ public:
 
   // get the prefix data in correct time order from beginning of last word to current node
   PathTrie* get_prev_word(std::vector<unsigned int>& output,
-                          std::vector<unsigned int>& timesteps,
                           const Alphabet& alphabet);
 
   // update log probs
@@ -65,7 +63,10 @@ public:
   float score;
   float approx_ctc;
   unsigned int character;
-  unsigned int timestep;
+  std::vector<unsigned int> timesteps;
+  // `timesteps_cur` is a temporary storage for each decoding step. 
+  // At the end of a decoding step, it is moved to `timesteps`.
+  std::vector<unsigned int> timesteps_cur; 
   PathTrie* parent;
 
 private:

--- a/native_client/ctcdecode/path_trie.h
+++ b/native_client/ctcdecode/path_trie.h
@@ -15,8 +15,8 @@
  * It is used to store the timesteps data for the PathTrie below
  */
 template<class DataT>
-struct TreeNode{
-	TreeNode<DataT>* parent;
+struct TreeNode {
+    TreeNode<DataT>* parent;
     std::vector<std::unique_ptr< TreeNode<DataT>, godefv::memory::object_pool_deleter_t<TreeNode<DataT>> >> children;
 
     DataT data;
@@ -30,7 +30,7 @@ TreeNode<NodeDataT>* add_child(TreeNode<NodeDataT>* node, ChildDataT&& data_);
 template<class DataT>
 std::vector<DataT> get_history(TreeNode<DataT>*);
 
-using TimestepTreeNode=TreeNode<unsigned int>;
+using TimestepTreeNode = TreeNode<unsigned int>;
 
 /* Trie tree for prefix storing and manipulating, with a dictionary in
  * finite-state transducer for spelling correction.
@@ -85,10 +85,10 @@ public:
   float score;
   float approx_ctc;
   unsigned int character;
-  TimestepTreeNode* timesteps=nullptr;
+  TimestepTreeNode* timesteps = nullptr;
 
   // timestep temporary storage for each decoding step. 
-  TimestepTreeNode* previous_timesteps=nullptr; 
+  TimestepTreeNode* previous_timesteps = nullptr; 
   unsigned int new_timestep;
 
   PathTrie* parent;
@@ -108,21 +108,21 @@ private:
 
 // TreeNode implementation
 template<class NodeDataT, class ChildDataT>
-TreeNode<NodeDataT>* add_child(TreeNode<NodeDataT>* node, ChildDataT&& data_){
-	static godefv::memory::object_pool_t<TreeNode<NodeDataT>> tree_node_pool;
-	node->children.push_back(tree_node_pool.make_unique(node, std::forward<ChildDataT>(data_)));
+TreeNode<NodeDataT>* add_child(TreeNode<NodeDataT>* node, ChildDataT&& data_) {
+    static godefv::memory::object_pool_t<TreeNode<NodeDataT>> tree_node_pool;
+    node->children.push_back(tree_node_pool.make_unique(node, std::forward<ChildDataT>(data_)));
     return node->children.back().get();
 }
 
 template<class DataT>
-void get_history_helper(TreeNode<DataT>* tree_node, std::vector<DataT>* output){
-    if(tree_node==nullptr) return;
-	assert(tree_node->parent != tree_node);
+void get_history_helper(TreeNode<DataT>* tree_node, std::vector<DataT>* output) {
+    if (tree_node == nullptr) return;
+    assert(tree_node->parent != tree_node);
     get_history_helper(tree_node->parent, output);
     output->push_back(tree_node->data);
 }
 template<class DataT>
-std::vector<DataT> get_history(TreeNode<DataT>* tree_node){
+std::vector<DataT> get_history(TreeNode<DataT>* tree_node) {
     std::vector<DataT> output;
     get_history_helper(tree_node, &output);
     return output;

--- a/native_client/ctcdecode/path_trie.h
+++ b/native_client/ctcdecode/path_trie.h
@@ -24,7 +24,7 @@ public:
   PathTrie* get_path_trie(unsigned int new_char, float log_prob_c, bool reset = true);
 
   // get the prefix data in correct time order from root to current node
-  std::vector<unsigned int> get_path_vec();
+  void get_path_vec(std::vector<unsigned int>& output);
 
   // get the prefix data in correct time order from beginning of last grapheme to current node
   PathTrie* get_prev_grapheme(std::vector<unsigned int>& output,

--- a/native_client/ctcdecode/path_trie.h
+++ b/native_client/ctcdecode/path_trie.h
@@ -24,11 +24,17 @@ struct TreeNode {
     TreeNode(TreeNode<DataT>* parent_, DataT const& data_): parent{parent_}, data{data_} {}
 };
 
+/* Creates a new TreeNode<NodeDataT> with given data as a child to the given node.
+ * Returns a pointer to the created node. This pointer remains valid as long as the child is not destroyed.
+ */
 template<class NodeDataT, class ChildDataT>
-TreeNode<NodeDataT>* add_child(TreeNode<NodeDataT>* node, ChildDataT&& data_);
+TreeNode<NodeDataT>* add_child(TreeNode<NodeDataT>* tree_node, ChildDataT&& data);
 
+/* Returns the sequence of tree node's data from the given root (exclusive) to the given tree_node (inclusive).
+ * By default (if no root is provided), the full sequence from the root of the tree is returned.
+ */
 template<class DataT>
-std::vector<DataT> get_history(TreeNode<DataT> const*, TreeNode<DataT> const* = nullptr);
+std::vector<DataT> get_history(TreeNode<DataT> const* tree_node, TreeNode<DataT> const* root = nullptr);
 
 using TimestepTreeNode = TreeNode<unsigned int>;
 
@@ -108,10 +114,10 @@ private:
 
 // TreeNode implementation
 template<class NodeDataT, class ChildDataT>
-TreeNode<NodeDataT>* add_child(TreeNode<NodeDataT>* node, ChildDataT&& data_) {
+TreeNode<NodeDataT>* add_child(TreeNode<NodeDataT>* tree_node, ChildDataT&& data) {
     static thread_local godefv::memory::object_pool_t<TreeNode<NodeDataT>> tree_node_pool;
-    node->children.push_back(tree_node_pool.make_unique(node, std::forward<ChildDataT>(data_)));
-    return node->children.back().get();
+    tree_node->children.push_back(tree_node_pool.make_unique(tree_node, std::forward<ChildDataT>(data)));
+    return tree_node->children.back().get();
 }
 
 template<class DataT>

--- a/native_client/ctcdecode/path_trie.h
+++ b/native_client/ctcdecode/path_trie.h
@@ -9,6 +9,7 @@
 
 #include "fst/fstlib.h"
 #include "alphabet.h"
+#include "object_pool.h"
 
 /* Tree structure with parent and children information
  * It is used to store the timesteps data for the PathTrie below
@@ -108,7 +109,8 @@ private:
 // TreeNode implementation
 template<class NodeDataT, class ChildDataT>
 std::shared_ptr<TreeNode<NodeDataT>> add_child(std::shared_ptr<TreeNode<NodeDataT>> const& node, ChildDataT&& data_){
-    node->children.push_back(std::make_shared<TreeNode<NodeDataT>>(node, std::forward<ChildDataT>(data_)));
+	static godefv::memory::object_pool_t<TreeNode<NodeDataT>> tree_node_pool;
+	node->children.emplace_back(tree_node_pool.make_unique(node, std::forward<ChildDataT>(data_)));
     return node->children.back();
 }
 

--- a/native_client/ctcdecode/path_trie.h
+++ b/native_client/ctcdecode/path_trie.h
@@ -17,7 +17,7 @@
 template<class DataT>
 struct TreeNode {
     TreeNode<DataT>* parent;
-    std::vector<std::unique_ptr< TreeNode<DataT>, godefv::memory::object_pool_deleter_t<TreeNode<DataT>> >> children;
+    std::vector<std::unique_ptr< TreeNode<DataT>, godefv::object_pool_deleter_t<TreeNode<DataT>> >> children;
 
     DataT data;
 
@@ -115,7 +115,7 @@ private:
 // TreeNode implementation
 template<class NodeDataT, class ChildDataT>
 TreeNode<NodeDataT>* add_child(TreeNode<NodeDataT>* tree_node, ChildDataT&& data) {
-    static thread_local godefv::memory::object_pool_t<TreeNode<NodeDataT>> tree_node_pool;
+    static thread_local godefv::object_pool_t<TreeNode<NodeDataT>> tree_node_pool;
     tree_node->children.push_back(tree_node_pool.make_unique(tree_node, std::forward<ChildDataT>(data)));
     return tree_node->children.back().get();
 }

--- a/native_client/ctcdecode/path_trie.h
+++ b/native_client/ctcdecode/path_trie.h
@@ -64,9 +64,11 @@ public:
   float approx_ctc;
   unsigned int character;
   std::vector<unsigned int> timesteps;
-  // `timesteps_cur` is a temporary storage for each decoding step. 
-  // At the end of a decoding step, it is moved to `timesteps`.
-  std::vector<unsigned int> timesteps_cur; 
+
+  // timestep temporary storage for each decoding step. 
+  std::vector<unsigned int>* previous_timesteps=nullptr; 
+  unsigned int new_timestep;
+
   PathTrie* parent;
 
 private:

--- a/native_client/ctcdecode/path_trie.h
+++ b/native_client/ctcdecode/path_trie.h
@@ -16,16 +16,16 @@
  */
 template<class DataT>
 struct TreeNode{
-	std::shared_ptr<TreeNode<DataT>> parent;
-    std::vector<std::shared_ptr<TreeNode<DataT>>> children;
+	TreeNode<DataT>* parent;
+    std::vector<std::unique_ptr< TreeNode<DataT>, godefv::memory::object_pool_deleter_t<TreeNode<DataT>> >> children;
 
     DataT data;
 
-    TreeNode(std::shared_ptr<TreeNode<DataT>> const& parent_, DataT const& data_): parent{parent_}, data{data_} {}
+    TreeNode(TreeNode<DataT>* parent_, DataT const& data_): parent{parent_}, data{data_} {}
 };
 
 template<class NodeDataT, class ChildDataT>
-std::shared_ptr<TreeNode<NodeDataT>> add_child(std::shared_ptr<TreeNode<NodeDataT>> const& node, ChildDataT&& data_);
+TreeNode<NodeDataT>* add_child(TreeNode<NodeDataT>* node, ChildDataT&& data_);
 
 template<class DataT>
 std::vector<DataT> get_history(TreeNode<DataT>*);
@@ -85,10 +85,10 @@ public:
   float score;
   float approx_ctc;
   unsigned int character;
-  std::shared_ptr<TimestepTreeNode> timesteps;
+  TimestepTreeNode* timesteps=nullptr;
 
   // timestep temporary storage for each decoding step. 
-  std::shared_ptr<TimestepTreeNode> previous_timesteps=nullptr; 
+  TimestepTreeNode* previous_timesteps=nullptr; 
   unsigned int new_timestep;
 
   PathTrie* parent;
@@ -108,21 +108,21 @@ private:
 
 // TreeNode implementation
 template<class NodeDataT, class ChildDataT>
-std::shared_ptr<TreeNode<NodeDataT>> add_child(std::shared_ptr<TreeNode<NodeDataT>> const& node, ChildDataT&& data_){
+TreeNode<NodeDataT>* add_child(TreeNode<NodeDataT>* node, ChildDataT&& data_){
 	static godefv::memory::object_pool_t<TreeNode<NodeDataT>> tree_node_pool;
-	node->children.emplace_back(tree_node_pool.make_unique(node, std::forward<ChildDataT>(data_)));
-    return node->children.back();
+	node->children.push_back(tree_node_pool.make_unique(node, std::forward<ChildDataT>(data_)));
+    return node->children.back().get();
 }
 
 template<class DataT>
-void get_history_helper(std::shared_ptr<TreeNode<DataT>> const& tree_node, std::vector<DataT>* output){
+void get_history_helper(TreeNode<DataT>* tree_node, std::vector<DataT>* output){
     if(tree_node==nullptr) return;
 	assert(tree_node->parent != tree_node);
     get_history_helper(tree_node->parent, output);
     output->push_back(tree_node->data);
 }
 template<class DataT>
-std::vector<DataT> get_history(std::shared_ptr<TreeNode<DataT>> const& tree_node){
+std::vector<DataT> get_history(TreeNode<DataT>* tree_node){
     std::vector<DataT> output;
     get_history_helper(tree_node, &output);
     return output;

--- a/native_client/ctcdecode/scorer.cpp
+++ b/native_client/ctcdecode/scorer.cpp
@@ -293,12 +293,12 @@ std::vector<std::string> Scorer::make_ngram(PathTrie* prefix)
     }
 
     std::vector<unsigned int> prefix_vec;
-    std::vector<unsigned int> prefix_steps;
+    std::vector<unsigned int> prefix_steps = current_node->timesteps;
 
     if (is_utf8_mode_) {
-      new_node = current_node->get_prev_grapheme(prefix_vec, prefix_steps, alphabet_);
+      new_node = current_node->get_prev_grapheme(prefix_vec, alphabet_);
     } else {
-      new_node = current_node->get_prev_word(prefix_vec, prefix_steps, alphabet_);
+      new_node = current_node->get_prev_word(prefix_vec, alphabet_);
     }
     current_node = new_node->parent;
 

--- a/native_client/ctcdecode/scorer.cpp
+++ b/native_client/ctcdecode/scorer.cpp
@@ -293,7 +293,6 @@ std::vector<std::string> Scorer::make_ngram(PathTrie* prefix)
     }
 
     std::vector<unsigned int> prefix_vec;
-    std::vector<unsigned int> prefix_steps = current_node->timesteps;
 
     if (is_utf8_mode_) {
       new_node = current_node->get_prev_grapheme(prefix_vec, alphabet_);

--- a/native_client/ctcdecode/third_party/object_pool/README.mozilla
+++ b/native_client/ctcdecode/third_party/object_pool/README.mozilla
@@ -1,0 +1,1 @@
+This code was imported from https://github.com/godefv/memory on September 17th 2020, commit 5ff1af8ee09ced04990b4863b2c02a8d07f4356a. It's licensed under "CC0 1.0 Universal" license.

--- a/native_client/ctcdecode/third_party/object_pool/object_pool.h
+++ b/native_client/ctcdecode/third_party/object_pool/object_pool.h
@@ -6,12 +6,13 @@
 #include <vector>
 #include <array>
 
-namespace godefv{ namespace memory{
+namespace godefv{
 
+// Forward declaration
 template<class Object, template<class T> class Allocator = std::allocator, std::size_t ChunkSize = 1024>
 class object_pool_t;
 
-//! Custom deleter to recycle the deleted pointers. 
+//! Custom deleter to recycle the deleted pointers of the object_pool_t. 
 template<class Object, template<class T> class Allocator = std::allocator, std::size_t ChunkSize = 1024>
 struct object_pool_deleter_t{
 private:
@@ -21,7 +22,6 @@ public:
 		object_pool_ptr(input_object_pool_ptr)
 	{}
 
-	//! When a pointer provided by the ObjectPool is deleted, its memory is converted to an object slot to be recycled. 
 	void operator()(Object* object_ptr)
 	{
 		object_pool_ptr->delete_object(object_ptr);
@@ -48,6 +48,7 @@ class object_pool_t{
 	object_slot_t* free_object_slots_begin; 
 	object_slot_t* free_object_slots_end; 
 
+	//! When a pointer provided by the ObjectPool is deleted, its memory is converted to an object slot to be recycled. 
 	void delete_object(Object* object_ptr){
 		object_ptr->~Object();
 		recycled_object_slots.push_back(reinterpret_cast<object_slot_t*>(object_ptr));
@@ -60,8 +61,8 @@ public:
 	using object_unique_ptr_t = std::unique_ptr<object_t, deleter_t>; //!< The type returned by the object pool.
 
 	object_pool_t(Allocator<chunk_t> const& allocator = Allocator<chunk_t>{}) :
-		free_object_slots_begin{ free_object_slots_end }, // At the begining, set the 2 iterators at the same value to simulate a full pool.
-		chunk_allocator{ allocator }
+		chunk_allocator{ allocator },
+		free_object_slots_begin{ free_object_slots_end } // At the begining, set the 2 iterators at the same value to simulate a full pool.
 	{}
 
 	//! Returns a unique pointer to an object_t using an unused object slot from the object pool. 
@@ -102,6 +103,6 @@ public:
 	}
 };
 
-}} /* namespace godefv::memory */
+} /* namespace godefv */
 
 #endif /* GODEFV_MEMORY_OBJECT_POOL_H */

--- a/native_client/ctcdecode/third_party/object_pool/object_pool.h
+++ b/native_client/ctcdecode/third_party/object_pool/object_pool.h
@@ -1,0 +1,97 @@
+#ifndef GODEFV_MEMORY_OBJECT_POOL_H
+#define GODEFV_MEMORY_OBJECT_POOL_H
+
+#include "unique_ptr.h"
+#include <memory>
+#include <vector>
+#include <array>
+
+namespace godefv{ namespace memory{
+
+//! Allocates instances of Object efficiently (constant time and log((maximum number of Objects used at the same time)/ChunkSize) calls to malloc in the whole lifetime of the object pool). 
+//! When an instance returned by the object pool is destroyed, its allocated memory is recycled by the object pool. Defragmenting the object pool to free memory is not possible. 
+template<class Object, template<class T> class Allocator = std::allocator, std::size_t ChunkSize = 1024>
+class object_pool_t{
+	//! An object slot is an uninitialized memory space of the same size as Object. 
+	//! It is initially "free". It can then be "used" to construct an Object in place and the pointer to it is returned by the object pool. When the pointer is destroyed, the object slot is "recycled" and can be used again but it is not "free" anymore because "free" object slots are contiguous in memory.
+	using object_slot_t=std::array<char, sizeof(Object)>;
+
+	//! To minimize calls to malloc, the object slots are allocated in chunks. 
+	//! For example, if ChunkSize=8, a chunk may look like this : |used|recycled|used|used|recycled|free|free|free|. In this example, if more than 5 new Object are now asked from the object pool, at least one new chunk of 8 object slots will be allocated.
+	using chunk_t=std::array<object_slot_t, ChunkSize>; 
+	Allocator<chunk_t> chunk_allocator; //!< This allocator can be used to have aligned memory if required.
+	std::vector<unique_ptr_t<chunk_t, decltype(chunk_allocator)>> memory_chunks; 
+
+	//! Recycled object slots are tracked using a stack of pointers to them. When an object slot is recycled, a pointer to it is pushed in constant time. When a new object is constructed, a recycled object slot can be found and poped in constant time.
+	std::vector<object_slot_t*> recycled_object_slots;
+
+	object_slot_t* free_object_slots_begin; 
+	object_slot_t* free_object_slots_end; 
+
+	//! Custom deleter to recycle the deleted pointers. 
+	struct deleter_t{
+	private:
+		object_pool_t<Object, Allocator, ChunkSize>* object_pool_ptr;
+	public:
+		explicit deleter_t(decltype(object_pool_ptr) input_object_pool_ptr) :
+			object_pool_ptr(input_object_pool_ptr)
+		{}
+
+		//! When a pointer provided by the ObjectPool is deleted, its memory is converted to an object slot to be recycled. 
+		void operator()(Object* object_ptr)
+		{
+			object_ptr->~Object();
+			object_pool_ptr->recycled_object_slots.push_back(reinterpret_cast<object_slot_t*>(object_ptr));
+		}
+	};
+
+public:
+	using object_t = Object;
+	using object_unique_ptr_t = std::unique_ptr<object_t, deleter_t>; //!< The type returned by the object pool.
+
+	object_pool_t(Allocator<chunk_t> const& allocator = Allocator<chunk_t>{}) :
+		free_object_slots_begin{ free_object_slots_end }, // At the begining, set the 2 iterators at the same value to simulate a full pool.
+		chunk_allocator{ allocator }
+	{}
+
+	//! Returns a unique pointer to an object_t using an unused object slot from the object pool. 
+	template<class... Args> object_unique_ptr_t make_unique(Args&&... vars){
+		auto construct_object_unique_ptr=[&](object_slot_t* object_slot){
+			return object_unique_ptr_t{ new (reinterpret_cast<object_t*>(object_slot)) object_t{ std::forward<Args>(vars)... } , deleter_t{ this } };
+		};
+
+		// If a recycled object slot is available, use it.
+		if (!recycled_object_slots.empty())
+		{
+			auto object_slot = recycled_object_slots.back();
+			recycled_object_slots.pop_back();
+			return construct_object_unique_ptr(object_slot);
+		}
+
+		// If the pool is full: add a new chunk.
+		if (free_object_slots_begin == free_object_slots_end)
+		{
+			memory_chunks.emplace_back(chunk_allocator);
+			auto& new_chunk = memory_chunks.back();
+			free_object_slots_begin=new_chunk->data();
+			free_object_slots_end  =free_object_slots_begin+new_chunk->size();
+		}
+
+		// We know that there is now at least one free object slot, use it.
+		return construct_object_unique_ptr(free_object_slots_begin++);
+	}
+
+	//! Returns the total number of object slots (free, recycled, or used).
+	std::size_t capacity() const{
+		return memory_chunks.size()*ChunkSize;
+	}
+
+	//! Returns the number of currently used object slots.
+	std::size_t size() const{
+		return capacity() - static_cast<std::size_t>(free_object_slots_end-free_object_slots_begin) - recycled_object_slots.size();
+	}
+};
+
+}} /* namespace godefv::memory */
+
+#endif /* GODEFV_MEMORY_OBJECT_POOL_H */

--- a/native_client/ctcdecode/third_party/object_pool/unique_ptr.h
+++ b/native_client/ctcdecode/third_party/object_pool/unique_ptr.h
@@ -1,0 +1,39 @@
+#ifndef GODEFV_MEMORY_ALLOCATED_UNIQUE_PTR_H
+#define GODEFV_MEMORY_ALLOCATED_UNIQUE_PTR_H
+
+#include <memory>
+
+namespace godefv{ namespace memory{
+
+//! A deleter to deallocate memory which have been allocated by the given allocator.
+template <class Allocator> struct allocator_deleter_t
+{
+	allocator_deleter_t(Allocator const& allocator) :
+		mAllocator{ allocator }
+	{}
+
+	void operator()(typename Allocator::value_type* ptr)
+	{
+		mAllocator.deallocate(ptr, 1);
+	}
+
+private:
+	Allocator mAllocator;
+};
+
+//! A smart pointer like std::unique_ptr but templated on an allocator instead of a deleter.
+//! The deleter is deduced from the given allocator.
+template <class T, class Allocator = std::allocator<T>>
+class unique_ptr_t : public std::unique_ptr<T, allocator_deleter_t<Allocator>>
+{
+	using base_t = std::unique_ptr<T, allocator_deleter_t<Allocator>>;
+
+public:
+	unique_ptr_t(Allocator allocator = Allocator{}) :
+		base_t{ allocator.allocate(1), allocator_deleter_t<Allocator>{ allocator } }
+	{}
+};
+
+}} // namespace godefv::memory 
+
+#endif // GODEFV_MEMORY_ALLOCATED_UNIQUE_PTR_H 

--- a/native_client/ctcdecode/third_party/object_pool/unique_ptr.h
+++ b/native_client/ctcdecode/third_party/object_pool/unique_ptr.h
@@ -3,10 +3,11 @@
 
 #include <memory>
 
-namespace godefv{ namespace memory{
+namespace godefv{
 
 //! A deleter to deallocate memory which have been allocated by the given allocator.
-template <class Allocator> struct allocator_deleter_t
+template<class Allocator> 
+struct allocator_deleter_t
 {
 	allocator_deleter_t(Allocator const& allocator) :
 		mAllocator{ allocator }
@@ -23,17 +24,16 @@ private:
 
 //! A smart pointer like std::unique_ptr but templated on an allocator instead of a deleter.
 //! The deleter is deduced from the given allocator.
-template <class T, class Allocator = std::allocator<T>>
-class unique_ptr_t : public std::unique_ptr<T, allocator_deleter_t<Allocator>>
+template<class T, class Allocator = std::allocator<T>>
+struct unique_ptr_t : public std::unique_ptr<T, allocator_deleter_t<Allocator>>
 {
 	using base_t = std::unique_ptr<T, allocator_deleter_t<Allocator>>;
 
-public:
 	unique_ptr_t(Allocator allocator = Allocator{}) :
 		base_t{ allocator.allocate(1), allocator_deleter_t<Allocator>{ allocator } }
 	{}
 };
 
-}} // namespace godefv::memory 
+} // namespace godefv 
 
 #endif // GODEFV_MEMORY_ALLOCATED_UNIQUE_PTR_H 


### PR DESCRIPTION
This follows the issue #3180 .

I suggest a new way of handling timesteps produced by the CTC decoder. There is no strange heuristic, and I think the logic is clear : when fusing two different paths leading to the same prefix, not only fuse the probabilities (the probabilities are added), but also fuse the timestep sequences (for the last letter in the sequence, choose the timestep from the most probable path).

The place where two different paths leading to the same prefix are fused are the places where `log_sum_exp` is called, because this function fuses the probabilities. So, timesteps would now be fused at the same places.

The other change is that each `PathTrie` node would now store the full sequence of timesteps. This is because one prefix can be an ancestor of another and their timesteps on a given node can differ. Having the full sequence of timesteps in each node, we have no need to duplicate a node with different timesteps, and it is much simpler like that. 
Moreover, it makes sense to store the *full* sequence of timesteps, because the *combined* probabilities are also stored there. The total probability is not the sum of the probability of each output token, and, in the same way, the correct sequence of timesteps is not the concatenation of the timestep of each output token.

Since I need to compare the probability of different paths (to keep the timesteps of the most probable one), it is important to compare paths of the same length (eg. paths from the beginning up to the current time). So, exactly the same way as it is done for the probabilities, I need to know the timesteps of the previous time, and store the timesteps of the current time separately.

In the end, timesteps are handled in a way very similar to the way probabilities are handled.

### Results on an example
To evaluate the resulting timesteps, I first take the argmax of my logits. In my example, it gives :
```
tou_________________________________________________ss  les  _a__mouurreuux  de  se_p_ort__ diiivverrr_  ss'enn__ _r_é___j_uuii__rr__on_t____    aa_v_eecc_   l''aap__p_rroo___chhee_____    de_  ll'hhi__v_e_rr____  et   la   rre__p_rri_ssee  dee  la  c_ouppee ddu  mon_deee      ss__kk_i___      less    ii_mm_a__ggees_   de   _g_ll_i_ss__ssee____________________             ree__t_rrou_vveennt    uunee    __pllaa___cee____      de    _cchhooixx__  d_ans_  lles  _pp_a____ggeess        ssspp_o_r_t_ii_vees_  de  v_o_s_ _jourrnnaauxx  ttéé_l_é___v_ii___ss_é__s__      ddeeu_x_   __é___pprreeuu_vvees___________________          _auu_jjoouurrdd''hhuuii___       _o____nno___rr_o_____d__a___mm________ ___s___a_n______t__a______  _q__a___tt__e___rr_i____n__a_____     __p_r____mmie_r__  s__a___l__o___m___    _g_é____ant__  de   lla  _c_ou_ppee  ddu   m_on___deee____________________________________________________
```
As the logits are the only input of the decoder, I base my evaluation on them instead of comparing with the audio file directly. It is known that the CTC loss does not guarantee alignment between the audio file and the logits, so the best thing the decoder can do is to fit the logits as best as it can. This is reasonable because, in practice, the logits are aligned quite well with the audio file.

Then, for each word, I take the part of the logits corresponding to the output timesteps, take the argmax (as said above), and print the corresponding decoded text. 

Finally, I assume that good timesteps should lead to a good match between the word and its corresponding text decoded from the argmax of the logits.

Before this PR, the result in my example is (text between slashes is from the logits argmax, spaces are trimmed) : 
```
[WordScoreRange(word=tous /tou/, score=None, ranges=((0, 4),)),   
 WordScoreRange(word=les /les/, score=None, ranges=((55, 59),)),       
 WordScoreRange(word=amoureux /amoureu/, score=None, ranges=((60, 74),)),
 WordScoreRange(word=de /d/, score=None, ranges=((75, 78),)),           
 WordScoreRange(word=sport /seport/, score=None, ranges=((80, 90),)),           
 WordScoreRange(word=divers /diver/, score=None, ranges=((91, 102),)),
 WordScoreRange(word=s'en /s'en/, score=None, ranges=((103, 111),)),  
 WordScoreRange(word=réjouiront /réjuiron/, score=None, ranges=((112, 136),)),
 WordScoreRange(word=avec /avec/, score=None, ranges=((141, 153),)),  
 WordScoreRange(word=l'approche /l'approche/, score=None, ranges=((155, 179),)),
 WordScoreRange(word=de /de/, score=None, ranges=((185, 191),)),  
 WordScoreRange(word=l'hiver /l'hive/, score=None, ranges=((192, 206),)),
 WordScoreRange(word=et /e/, score=None, ranges=((208, 215),)),
 WordScoreRange(word=la /la/, score=None, ranges=((217, 221),)),
 WordScoreRange(word=reprise /reprise/, score=None, ranges=((222, 238),)),
 WordScoreRange(word=de /de/, score=None, ranges=((240, 243),)),
 WordScoreRange(word=la /la/, score=None, ranges=((244, 248),)),
 WordScoreRange(word=coupe /coupe/, score=None, ranges=((249, 257),)),
 WordScoreRange(word=du /d/, score=None, ranges=((258, 261),)),
 WordScoreRange(word=monde /monde/, score=None, ranges=((263, 270),)),
 WordScoreRange(word=de /e/, score=None, ranges=((271, 275),)),
 WordScoreRange(word=ski /ski/, score=None, ranges=((276, 286),)),
 WordScoreRange(word=les /les/, score=None, ranges=((290, 298),)),
 WordScoreRange(word=images /image/, score=None, ranges=((300, 316),)),
 WordScoreRange(word=de /d/, score=None, ranges=((318, 322),)),
 WordScoreRange(word=glisse /glisse/, score=None, ranges=((324, 341),)),
 WordScoreRange(word=retrouvent /retrouvent/, score=None, ranges=((363, 394),)),
 WordScoreRange(word=une /une/, score=None, ranges=((395, 402),)),
 WordScoreRange(word=place /place/, score=None, ranges=((404, 419),)),
 WordScoreRange(word=de /de/, score=None, ranges=((425, 432),)),
 WordScoreRange(word=choix /choix/, score=None, ranges=((433, 445),)),
 WordScoreRange(word=dans /dans/, score=None, ranges=((448, 455),)),
 WordScoreRange(word=les /les/, score=None, ranges=((457, 462),)),
 WordScoreRange(word=pages /pages/, score=None, ranges=((463, 478),)),
 WordScoreRange(word=sportives /sportives/, score=None, ranges=((479, 506),)),
 WordScoreRange(word=de /de/, score=None, ranges=((508, 511),)),
 WordScoreRange(word=vos /vos/, score=None, ranges=((512, 518),)),
 WordScoreRange(word=journaux /journaux/, score=None, ranges=((520, 532),)),
 WordScoreRange(word=télévisés /télévisé/, score=None, ranges=((533, 559),)),
 WordScoreRange(word=deux /deux/, score=None, ranges=((563, 575),)),
 WordScoreRange(word=épreuves /épreuve/, score=None, ranges=((577, 598),)),
 WordScoreRange(word=aujourd'hui /aujourd'hu/, score=None, ranges=((618, 649),)),
 WordScoreRange(word=on /o/, score=None, ranges=((654, 665),)),
 WordScoreRange(word=a /am/, score=None, ranges=((685, 699),)),
 WordScoreRange(word=santa /santa/, score=None, ranges=((703, 726),)),
 WordScoreRange(word=caterina /qaterina/, score=None, ranges=((729, 756),)),
 WordScoreRange(word=premier /prmier/, score=None, ranges=((762, 783),)),
 WordScoreRange(word=salon /salom/, score=None, ranges=((785, 803),)),
 WordScoreRange(word=géant /géant/, score=None, ranges=((805, 818),)),
 WordScoreRange(word=de /d/, score=None, ranges=((819, 823),)),
 WordScoreRange(word=la /l/, score=None, ranges=((825, 829),)),
 WordScoreRange(word=coupe /coupe/, score=None, ranges=((831, 841),)),
 WordScoreRange(word=du /d/, score=None, ranges=((842, 846),)),
 WordScoreRange(word=monde /mon/, score=None, ranges=((848, 857),))]
```

After this PR, the result in my example is : 
```
[WordScoreRange(word=tous /tous/, score=None, ranges=((0, 54),)), 
 WordScoreRange(word=les /les/, score=None, ranges=((56, 59),)),        
 WordScoreRange(word=amoureux /amoureux/, score=None, ranges=((62, 75),)),
 WordScoreRange(word=de /de/, score=None, ranges=((77, 79),)),          
 WordScoreRange(word=sport /seport/, score=None, ranges=((81, 91),)),           
 WordScoreRange(word=divers /diver/, score=None, ranges=((92, 103),)),
 WordScoreRange(word=s'en /s'en/, score=None, ranges=((105, 113),)),  
 WordScoreRange(word=réjouiront /réjuiront/, score=None, ranges=((114, 140),)),
 WordScoreRange(word=avec /avec/, score=None, ranges=((145, 155),)),  
 WordScoreRange(word=l'approche /l'approche/, score=None, ranges=((158, 185),)),
 WordScoreRange(word=de /de/, score=None, ranges=((189, 192),)),  
 WordScoreRange(word=l'hiver /l'hiver/, score=None, ranges=((194, 212),)),
 WordScoreRange(word=et /et/, score=None, ranges=((214, 216),)),                                                               
 WordScoreRange(word=la /la/, score=None, ranges=((219, 221),)),
 WordScoreRange(word=reprise /reprise/, score=None, ranges=((224, 239),)),                                                                                                                         
 WordScoreRange(word=de /de/, score=None, ranges=((241, 244),)),            
 WordScoreRange(word=la /la/, score=None, ranges=((246, 248),)),              
 WordScoreRange(word=coupe /coupe/, score=None, ranges=((250, 258),)),
 WordScoreRange(word=du /du/, score=None, ranges=((259, 262),)),            
 WordScoreRange(word=monde /monde/, score=None, ranges=((264, 272),)),
 WordScoreRange(word=de //, score=None, ranges=((273, 275),)),
 WordScoreRange(word=ski /ski/, score=None, ranges=((278, 289),)),
 WordScoreRange(word=les /les/, score=None, ranges=((295, 299),)),
 WordScoreRange(word=images /images/, score=None, ranges=((303, 318),)),
 WordScoreRange(word=de /de/, score=None, ranges=((321, 323),)),
 WordScoreRange(word=glisse /glisse/, score=None, ranges=((327, 362),)),
 WordScoreRange(word=retrouvent /retrouvent/, score=None, ranges=((375, 394),)),
 WordScoreRange(word=une /une/, score=None, ranges=((398, 403),)),
 WordScoreRange(word=place /place/, score=None, ranges=((409, 424),)),
 WordScoreRange(word=de /de/, score=None, ranges=((430, 432),)),
 WordScoreRange(word=choix /choix/, score=None, ranges=((437, 448),)),
 WordScoreRange(word=dans /dans/, score=None, ranges=((450, 456),)),
 WordScoreRange(word=les /les/, score=None, ranges=((458, 462),)),
 WordScoreRange(word=pages /pages/, score=None, ranges=((465, 479),)),
 WordScoreRange(word=sportives /sportives/, score=None, ranges=((487, 507),)),
 WordScoreRange(word=de /de/, score=None, ranges=((509, 511),)),
 WordScoreRange(word=vos /vos/, score=None, ranges=((513, 519),)),
 WordScoreRange(word=journaux /journaux/, score=None, ranges=((521, 533),)),
 WordScoreRange(word=télévisés /télévisés/, score=None, ranges=((535, 562),)),
 WordScoreRange(word=deux /deux/, score=None, ranges=((568, 576),)),
 WordScoreRange(word=épreuves /épreuves/, score=None, ranges=((581, 618),)),
 WordScoreRange(word=aujourd'hui /aujourd'hui/, score=None, ranges=((629, 654),)),
 WordScoreRange(word=on /onoro/, score=None, ranges=((662, 680),)),
 WordScoreRange(word=a /am/, score=None, ranges=((685, 699),)),
 WordScoreRange(word=santa /santa/, score=None, ranges=((703, 726),)),
 WordScoreRange(word=caterina /qaterina/, score=None, ranges=((729, 761),)),
 WordScoreRange(word=premier /prmier/, score=None, ranges=((768, 783),)),
 WordScoreRange(word=salon /salom/, score=None, ranges=((785, 803),)),
 WordScoreRange(word=géant /géant/, score=None, ranges=((808, 820),)),
 WordScoreRange(word=de /de/, score=None, ranges=((822, 824),)),
 WordScoreRange(word=la /l/, score=None, ranges=((826, 829),)),
 WordScoreRange(word=coupe /coupe/, score=None, ranges=((833, 842),)),
 WordScoreRange(word=du /d/, score=None, ranges=((843, 846),)),
 WordScoreRange(word=monde /mond/, score=None, ranges=((850, 858),))]
```

We can see that before this PR, there are 17 words where timesteps are too early (about one letter shift, it is visible at the end but not at the begining of words because I have trimed spaces).
After this PR, the fit is almost prefect. For some reason, there are still 3 remaining errors, all in the 4 last words.