### PR TITLE
Fix for setuptools._distutils issue (#3295)

### DIFF
--- a/Dockerfile.train.tmpl
+++ b/Dockerfile.train.tmpl
@@ -41,7 +41,7 @@ RUN cd native_client/ctcdecode && make NUM_PROCESSES=$(nproc) bindings
 RUN pip3 install --upgrade native_client/ctcdecode/dist/*.whl
 
 # Prepare deps
-RUN pip3 install --upgrade pip==20.0.2 wheel==0.34.2 setuptools==46.1.3
+RUN pip3 install --upgrade pip==20.2.2 wheel==0.34.2 setuptools==49.6.0
 
 # Install DeepSpeech
 #  - No need for the decoder since we did it earlier


### PR DESCRIPTION
This is a simple fix for being able to build once again any release DS following problems that have arisen after setuptool 50.0.0 release. 

https://github.com/mozilla/DeepSpeech/issues/3295#issuecomment-685476173

Cheers!