### PR TITLE
enable hot-words boosting for Javascript

### DIFF
--- a/native_client/javascript/client.ts
+++ b/native_client/javascript/client.ts
@@ -31,6 +31,7 @@ parser.addArgument(['--audio'], {required: true, help: 'Path to the audio file t
 parser.addArgument(['--version'], {action: VersionAction, nargs: 0, help: 'Print version and exits'});
 parser.addArgument(['--extended'], {action: 'storeTrue', help: 'Output string from extended metadata'});
 parser.addArgument(['--stream'], {action: 'storeTrue', help: 'Use streaming code path (for tests)'});
+parser.addArgument(['--hot_words'], {help: 'Hot-words and their boosts. Word:Boost pairs are comma-separated'});
 let args = parser.parseArgs();
 
 function totalTime(hrtimeValue: number[]): string {
@@ -69,6 +70,14 @@ if (args['scorer']) {
   if (args['lm_alpha'] && args['lm_beta']) {
     model.setScorerAlphaBeta(args['lm_alpha'], args['lm_beta']);
   }
+}
+
+if (args['hot_words']) {
+	console.error('Adding hot-words %s', args['hot_words']);
+	for (let word_boost of args['hot_words'].split(',')) {
+		let word = word_boost.split(':');
+		model.addHotWord(word[0], parseFloat(word[1]));
+	}
 }
 
 const buffer = Fs.readFileSync(args['audio']);

--- a/native_client/javascript/index.ts
+++ b/native_client/javascript/index.ts
@@ -191,7 +191,7 @@ export class Model {
      * @throws on error
      */
      addHotWord(aWord: string, aBoost: number): void {
-        const status = binding.addHotWord(this._impl, aWord, aBoost);
+        const status = binding.AddHotWord(this._impl, aWord, aBoost);
         if (status !== 0) {
             throw `addHotWord failed: ${binding.ErrorCodeToErrorMessage(status)} (0x${status.toString(16)})`;
         }
@@ -205,7 +205,7 @@ export class Model {
      * @throws on error
      */
     eraseHotWord(aWord: string): void {
-        const status = binding.eraseHotWord(this._impl, aWord);
+        const status = binding.EraseHotWord(this._impl, aWord);
         if (status !== 0) {
             throw `eraseHotWord failed: ${binding.ErrorCodeToErrorMessage(status)} (0x${status.toString(16)})`;
         }
@@ -217,7 +217,7 @@ export class Model {
      * @throws on error
      */
     clearHotWords(): void {
-        const status = binding.clearHotWords(this._impl);
+        const status = binding.ClearHotWords(this._impl);
         if (status !== 0) {
             throw `clearHotWord failed: ${binding.ErrorCodeToErrorMessage(status)} (0x${status.toString(16)})`;
         }

--- a/taskcluster/tc-node-tests.sh
+++ b/taskcluster/tc-node-tests.sh
@@ -34,3 +34,5 @@ ensure_cuda_usage "$3"
 run_all_inference_tests
 
 run_js_streaming_inference_tests
+
+run_hotword_tests

--- a/taskcluster/tc-node_tflite-tests.sh
+++ b/taskcluster/tc-node_tflite-tests.sh
@@ -36,3 +36,5 @@ check_runtime_nodejs
 run_all_inference_tests
 
 run_js_streaming_inference_tests
+
+run_hotword_tests


### PR DESCRIPTION
This PR enables hot-word boosting for Javascript Binaries. 
For the issue #3336 