### PR TITLE
Tiny fix to addHotWord doc string parameters

### DIFF
--- a/native_client/python/__init__.py
+++ b/native_client/python/__init__.py
@@ -102,8 +102,8 @@ class Model(object):
         :param word: the hot-word
         :type word: str
 
-        :param word: the boost
-        :type word: float
+        :param boost: the boost
+        :type boost: float
 
         :throws: RuntimeError on error
         """


### PR DESCRIPTION
As the parameter for boost was actually written as "word" in the doc string, it was replacing the previous type for word with the type intended for boost and not showing any type for boost, thus messing up what displayed on https://deepspeech.readthedocs.io/en/master/Python-API.html