### PR TITLE
Remote I/O Training Setup

### DIFF
--- a/training/deepspeech_training/train.py
+++ b/training/deepspeech_training/train.py
@@ -775,7 +775,7 @@ def create_inference_graph(batch_size=1, n_steps=16, tflite=False):
 
 
 def file_relative_read(fname):
-    return open_remote(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
 def export():

--- a/training/deepspeech_training/train.py
+++ b/training/deepspeech_training/train.py
@@ -875,8 +875,12 @@ def export():
 def package_zip():
     # --export_dir path/to/export/LANG_CODE/ => path/to/export/LANG_CODE.zip
     export_dir = os.path.join(os.path.abspath(FLAGS.export_dir), '') # Force ending '/'
-    zip_filename = os.path.dirname(export_dir)
+    if is_remote_path(export_dir):
+        log_error("Cannot package remote path zip %s. Please do this manually." % export_dir)
+        return
 
+    zip_filename = os.path.dirname(export_dir)
+    
     shutil.copy(FLAGS.scorer_path, export_dir)
 
     archive = shutil.make_archive(zip_filename, 'zip', export_dir)

--- a/training/deepspeech_training/util/audio.py
+++ b/training/deepspeech_training/util/audio.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from .helpers import LimitingPool
 from collections import namedtuple
+from .io import open_remote, remove_remote, copy_remote, is_remote_path
 
 AudioFormat = namedtuple('AudioFormat', 'rate channels width')
 
@@ -168,29 +169,44 @@ class AudioFile:
         self.audio_format = audio_format
         self.as_path = as_path
         self.open_file = None
+        self.open_wav = None
         self.tmp_file_path = None
 
     def __enter__(self):
         if self.audio_path.endswith('.wav'):
-            self.open_file = wave.open(self.audio_path, 'r')
-            if read_audio_format_from_wav_file(self.open_file) == self.audio_format:
+            self.open_file = open_remote(self.audio_path, 'r')
+            self.open_wav = wave.open(self.open_file)
+            if read_audio_format_from_wav_file(self.open_wav) == self.audio_format:
                 if self.as_path:
+                    self.open_wav.close()
                     self.open_file.close()
                     return self.audio_path
-                return self.open_file
+                return self.open_wav
+            self.open_wav.close()
             self.open_file.close()
+
+        # If the format isn't right, copy the file to local tmp dir and do the conversion on disk
+        if is_remote_path(self.audio_path):
+            _, self.tmp_src_file_path = tempfile.mkstemp(suffix='.wav')
+            copy_remote(self.audio_path, self.tmp_src_file_path)
+            self.audio_path = self.tmp_file_path
+            
         _, self.tmp_file_path = tempfile.mkstemp(suffix='.wav')
         convert_audio(self.audio_path, self.tmp_file_path, file_type='wav', audio_format=self.audio_format)
         if self.as_path:
             return self.tmp_file_path
-        self.open_file = wave.open(self.tmp_file_path, 'r')
-        return self.open_file
+        self.open_wav = wave.open(self.tmp_file_path, 'r')
+        return self.open_wav
 
     def __exit__(self, *args):
         if not self.as_path:
-            self.open_file.close()
+            self.open_wav.close()
+            if self.open_file:
+                self.open_file.close()
         if self.tmp_file_path is not None:
             os.remove(self.tmp_file_path)
+        if self.tmp_src_file_path is not None:
+            os.remove(self.tmp_src_file_path)
 
 
 def read_frames(wav_file, frame_duration_ms=30, yield_remainder=False):
@@ -320,7 +336,7 @@ def read_opus(opus_file):
 
 
 def write_wav(wav_file, pcm_data, audio_format=DEFAULT_FORMAT):
-    with wave.open(wav_file, 'wb') as wav_file_writer:
+    with wave.open_remote(wav_file, 'wb') as wav_file_writer:
         wav_file_writer.setframerate(audio_format.rate)
         wav_file_writer.setnchannels(audio_format.channels)
         wav_file_writer.setsampwidth(audio_format.width)
@@ -329,7 +345,7 @@ def write_wav(wav_file, pcm_data, audio_format=DEFAULT_FORMAT):
 
 def read_wav(wav_file):
     wav_file.seek(0)
-    with wave.open(wav_file, 'rb') as wav_file_reader:
+    with wave.open_remote(wav_file, 'rb') as wav_file_reader:
         audio_format = read_audio_format_from_wav_file(wav_file_reader)
         pcm_data = wav_file_reader.readframes(wav_file_reader.getnframes())
         return audio_format, pcm_data
@@ -353,7 +369,7 @@ def write_audio(audio_type, audio_file, pcm_data, audio_format=DEFAULT_FORMAT, b
 
 def read_wav_duration(wav_file):
     wav_file.seek(0)
-    with wave.open(wav_file, 'rb') as wav_file_reader:
+    with wave.open_remote(wav_file, 'rb') as wav_file_reader:
         return wav_file_reader.getnframes() / wav_file_reader.getframerate()
 
 

--- a/training/deepspeech_training/util/audio.py
+++ b/training/deepspeech_training/util/audio.py
@@ -336,7 +336,8 @@ def read_opus(opus_file):
 
 
 def write_wav(wav_file, pcm_data, audio_format=DEFAULT_FORMAT):
-    with wave.open_remote(wav_file, 'wb') as wav_file_writer:
+    # wav_file is already a file-pointer here
+    with wave.open(wav_file, 'wb') as wav_file_writer:
         wav_file_writer.setframerate(audio_format.rate)
         wav_file_writer.setnchannels(audio_format.channels)
         wav_file_writer.setsampwidth(audio_format.width)
@@ -345,7 +346,7 @@ def write_wav(wav_file, pcm_data, audio_format=DEFAULT_FORMAT):
 
 def read_wav(wav_file):
     wav_file.seek(0)
-    with wave.open_remote(wav_file, 'rb') as wav_file_reader:
+    with wave.open(wav_file, 'rb') as wav_file_reader:
         audio_format = read_audio_format_from_wav_file(wav_file_reader)
         pcm_data = wav_file_reader.readframes(wav_file_reader.getnframes())
         return audio_format, pcm_data
@@ -369,7 +370,7 @@ def write_audio(audio_type, audio_file, pcm_data, audio_format=DEFAULT_FORMAT, b
 
 def read_wav_duration(wav_file):
     wav_file.seek(0)
-    with wave.open_remote(wav_file, 'rb') as wav_file_reader:
+    with wave.open(wav_file, 'rb') as wav_file_reader:
         return wav_file_reader.getnframes() / wav_file_reader.getframerate()
 
 

--- a/training/deepspeech_training/util/audio.py
+++ b/training/deepspeech_training/util/audio.py
@@ -171,6 +171,7 @@ class AudioFile:
         self.open_file = None
         self.open_wav = None
         self.tmp_file_path = None
+        self.tmp_src_file_path = None
 
     def __enter__(self):
         if self.audio_path.endswith('.wav'):

--- a/training/deepspeech_training/util/augmentations.py
+++ b/training/deepspeech_training/util/augmentations.py
@@ -150,6 +150,12 @@ def _init_augmentation_worker(preparation_context):
     AUGMENTATION_CONTEXT = preparation_context
 
 
+def _load_and_augment_sample(timed_sample, context=None):
+    sample, clock = timed_sample
+    realized_sample = sample.unpack()
+    return _augment_sample((realized_sample, clock), context)
+
+
 def _augment_sample(timed_sample, context=None):
     context = AUGMENTATION_CONTEXT if context is None else context
     sample, clock = timed_sample
@@ -213,12 +219,12 @@ def apply_sample_augmentations(samples,
         context = AugmentationContext(audio_type, augmentations)
         if process_ahead == 0:
             for timed_sample in timed_samples():
-                yield _augment_sample(timed_sample, context=context)
+                yield _load_and_augment_sample(timed_sample, context=context)
         else:
             with LimitingPool(process_ahead=process_ahead,
                               initializer=_init_augmentation_worker,
                               initargs=(context,)) as pool:
-                yield from pool.imap(_augment_sample, timed_samples())
+                yield from pool.imap(_load_and_augment_sample, timed_samples())
     finally:
         for augmentation in augmentations:
             augmentation.stop()

--- a/training/deepspeech_training/util/check_characters.py
+++ b/training/deepspeech_training/util/check_characters.py
@@ -28,7 +28,7 @@ def main():
     parser.add_argument("-alpha", "--alphabet-format", help="Bool. Print in format for alphabet.txt", action="store_true")
     parser.add_argument("-unicode", "--disable-unicode-variants", help="Bool. DISABLE check for unicode consistency (use with --alphabet-format)", action="store_true")
     args = parser.parse_args()
-    in_files = [os.path.abspath(i) for i in args.csv_files.split(",")]
+    in_files = args.csv_files.split(",")
 
     print("### Reading in the following transcript files: ###")
     print("### {} ###".format(in_files))

--- a/training/deepspeech_training/util/check_characters.py
+++ b/training/deepspeech_training/util/check_characters.py
@@ -19,6 +19,7 @@ import csv
 import os
 import sys
 import unicodedata
+from .util.io import open_remote
 
 def main():
     parser = argparse.ArgumentParser()
@@ -34,7 +35,7 @@ def main():
 
     all_text = set()
     for in_file in in_files:
-        with open(in_file, "r") as csv_file:
+        with open_remote(in_file, "r") as csv_file:
             reader = csv.reader(csv_file)
             try:
                 next(reader, None)  # skip the file header (i.e. "transcript")

--- a/training/deepspeech_training/util/check_characters.py
+++ b/training/deepspeech_training/util/check_characters.py
@@ -19,7 +19,7 @@ import csv
 import os
 import sys
 import unicodedata
-from .util.io import open_remote
+from .io import open_remote
 
 def main():
     parser = argparse.ArgumentParser()

--- a/training/deepspeech_training/util/config.py
+++ b/training/deepspeech_training/util/config.py
@@ -13,7 +13,7 @@ from .gpu import get_available_gpus
 from .logging import log_error, log_warn
 from .helpers import parse_file_size
 from .augmentations import parse_augmentations
-from .util.io import path_exists_remote
+from .io import path_exists_remote
 
 class ConfigSingleton:
     _config = None

--- a/training/deepspeech_training/util/config.py
+++ b/training/deepspeech_training/util/config.py
@@ -13,7 +13,7 @@ from .gpu import get_available_gpus
 from .logging import log_error, log_warn
 from .helpers import parse_file_size
 from .augmentations import parse_augmentations
-
+from .util.io import path_exists_remote
 
 class ConfigSingleton:
     _config = None
@@ -139,7 +139,7 @@ def initialize_globals():
     c.audio_step_samples = FLAGS.audio_sample_rate * (FLAGS.feature_win_step / 1000)
 
     if FLAGS.one_shot_infer:
-        if not os.path.exists(FLAGS.one_shot_infer):
+        if not path_exists_remote(FLAGS.one_shot_infer):
             log_error('Path specified in --one_shot_infer is not a valid file.')
             sys.exit(1)
 

--- a/training/deepspeech_training/util/downloader.py
+++ b/training/deepspeech_training/util/downloader.py
@@ -2,7 +2,7 @@ import requests
 import progressbar
 
 from os import path, makedirs
-from .io import open_remote, path_exists_remote
+from .io import open_remote, path_exists_remote, is_remote_path
 
 SIMPLE_BAR = ['Progress ', progressbar.Bar(), ' ', progressbar.Percentage(), ' completed']
 
@@ -10,7 +10,7 @@ def maybe_download(archive_name, target_dir, archive_url):
     # If archive file does not exist, download it...
     archive_path = path.join(target_dir, archive_name)
 
-    if not path_exists_remote(target_dir):
+    if not is_remote_path(target_dir) and not path.exists(target_dir):
         print('No path "%s" - creating ...' % target_dir)
         makedirs(target_dir)
 

--- a/training/deepspeech_training/util/downloader.py
+++ b/training/deepspeech_training/util/downloader.py
@@ -2,6 +2,7 @@ import requests
 import progressbar
 
 from os import path, makedirs
+from .io import open_remote, path_exists_remote
 
 SIMPLE_BAR = ['Progress ', progressbar.Bar(), ' ', progressbar.Percentage(), ' completed']
 
@@ -9,16 +10,16 @@ def maybe_download(archive_name, target_dir, archive_url):
     # If archive file does not exist, download it...
     archive_path = path.join(target_dir, archive_name)
 
-    if not path.exists(target_dir):
+    if not path_exists_remote(target_dir):
         print('No path "%s" - creating ...' % target_dir)
         makedirs(target_dir)
 
-    if not path.exists(archive_path):
+    if not path_exists_remote(archive_path):
         print('No archive "%s" - downloading...' % archive_path)
         req = requests.get(archive_url, stream=True)
         total_size = int(req.headers.get('content-length', 0))
         done = 0
-        with open(archive_path, 'wb') as f:
+        with open_remote(archive_path, 'wb') as f:
             bar = progressbar.ProgressBar(max_value=total_size, widgets=SIMPLE_BAR)
             for data in req.iter_content(1024*1024):
                 done += len(data)

--- a/training/deepspeech_training/util/evaluate_tools.py
+++ b/training/deepspeech_training/util/evaluate_tools.py
@@ -10,7 +10,7 @@ from attrdict import AttrDict
 
 from .flags import FLAGS
 from .text import levenshtein
-
+from .io import open_remote
 
 def pmap(fun, iterable):
     pool = Pool()
@@ -124,5 +124,5 @@ def save_samples_json(samples, output_path):
         We set ensure_ascii=True to prevent json from escaping non-ASCII chars
         in the texts.
     '''
-    with open(output_path, 'w') as fout:
+    with open_remote(output_path, 'w') as fout:
         json.dump(samples, fout, default=float, ensure_ascii=False, indent=2)

--- a/training/deepspeech_training/util/helpers.py
+++ b/training/deepspeech_training/util/helpers.py
@@ -103,11 +103,6 @@ class LimitingPool:
             self.processed -= 1
             yield obj
 
-    def imap_unordered(self, fun, it):
-        for obj in self.pool.imap_unordered(fun, self._limit(it)):
-            self.processed -= 1
-            yield obj
-
     def terminate(self):
         self.pool.terminate()
 

--- a/training/deepspeech_training/util/helpers.py
+++ b/training/deepspeech_training/util/helpers.py
@@ -103,6 +103,11 @@ class LimitingPool:
             self.processed -= 1
             yield obj
 
+    def imap_unordered(self, fun, it):
+        for obj in self.pool.imap_unordered(fun, self._limit(it)):
+            self.processed -= 1
+            yield obj
+
     def terminate(self):
         self.pool.terminate()
 

--- a/training/deepspeech_training/util/io.py
+++ b/training/deepspeech_training/util/io.py
@@ -1,0 +1,76 @@
+"""
+A set of I/O utils that allow us to open files on remote storage as if they were present locally.
+Currently only includes wrappers for Google's GCS, but this can easily be expanded for AWS S3 buckets.
+"""
+import inspect
+import os
+import sys
+
+def path_exists_remote(path):
+    """
+    Wrapper that allows existance check of local and remote paths like
+    `gs://...`
+    """
+    # Conditional import
+    if path.startswith("gs://"):
+        from tensorflow.io import gfile
+        return gfile.exists(path)
+    return path_exists_remotes(path)
+
+
+def open_remote(path, mode):
+    """
+    Wrapper around open_remote() method that can handle remote paths like `gs://...`
+    off Google Cloud using Tensorflow's IO helpers.
+
+    This enables us to do:
+    with open_remote('gs://.....', mode='w+') as f:
+        do something with the file f, whether or not we have local access to it
+    """
+    # Conditional import
+    if path.startswith("gs://"):
+        from tensorflow.io import gfile
+        return gfile.GFile(path, mode=mode)
+    return open_remote(path, mode)
+
+
+def isdir_remote(path):
+    """
+    Wrapper to check if remote and local paths are directories
+    """
+    # Conditional import
+    if path.startswith("gs://"):
+        from tensorflow.io import gfile
+        return gfile.isdir(path)
+    return isdir_remote(path)
+
+
+def listdir_remote(path):
+    """
+    Wrapper to list paths in local dirs (alternative to using a glob, I suppose)
+    """
+    # Conditional import
+    if path.startswith("gs://"):
+        from tensorflow.io import gfile
+        return gfile.listdir(path)
+    return os.listdir(path)
+
+
+def glob_remote(filename):
+    """
+    Wrapper that provides globs on local and remote paths like `gs://...`
+    """
+    # Conditional import
+    from tensorflow.io import gfile
+
+    return gfile.glob(filename)
+
+
+def remove_remote(filename):
+    """
+    Wrapper that can remove_remote local and remote files like `gs://...`
+    """
+    # Conditional import
+    from tensorflow.io import gfile
+
+    return gfile.remove_remote(filename)

--- a/training/deepspeech_training/util/io.py
+++ b/training/deepspeech_training/util/io.py
@@ -36,10 +36,12 @@ def copy_remote(src, dst, overwrite=False):
     return gfile.copy(src, dst, overwrite)
 
 
-def open_remote(path, mode):
+def open_remote(path, mode='r', buffering=-1, encoding=None, newline=None, closefd=True, opener=None):
     """
     Wrapper around open_remote() method that can handle remote paths like `gs://...`
     off Google Cloud using Tensorflow's IO helpers.
+
+    buffering, encoding, newline, closefd, and opener are ignored for remote files
 
     This enables us to do:
     with open_remote('gs://.....', mode='w+') as f:
@@ -49,7 +51,7 @@ def open_remote(path, mode):
     if is_remote_path(path):
         from tensorflow.io import gfile
         return gfile.GFile(path, mode=mode)
-    return open_remote(path, mode)
+    return open(path, mode, buffering=buffering, encoding=encoding, newline=newline, closefd=closefd, opener=opener)
 
 
 def isdir_remote(path):

--- a/training/deepspeech_training/util/io.py
+++ b/training/deepspeech_training/util/io.py
@@ -15,7 +15,7 @@ def path_exists_remote(path):
     if path.startswith("gs://"):
         from tensorflow.io import gfile
         return gfile.exists(path)
-    return path_exists_remotes(path)
+    return os.path.exists(path)
 
 
 def open_remote(path, mode):
@@ -42,7 +42,7 @@ def isdir_remote(path):
     if path.startswith("gs://"):
         from tensorflow.io import gfile
         return gfile.isdir(path)
-    return isdir_remote(path)
+    return os.path.isdir(path)
 
 
 def listdir_remote(path):

--- a/training/deepspeech_training/util/io.py
+++ b/training/deepspeech_training/util/io.py
@@ -3,9 +3,8 @@ A set of I/O utils that allow us to open files on remote storage as if they were
 into HDFS storage using Tensorflow's C++ FileStream API.
 Currently only includes wrappers for Google's GCS, but this can easily be expanded for AWS S3 buckets.
 """
-import inspect
 import os
-import sys
+from tensorflow.io import gfile
 
 
 def is_remote_path(path):
@@ -21,9 +20,7 @@ def path_exists_remote(path):
     Wrapper that allows existance check of local and remote paths like
     `gs://...`
     """
-    # Conditional import
     if is_remote_path(path):
-        from tensorflow.io import gfile
         return gfile.exists(path)
     return os.path.exists(path)
 
@@ -32,7 +29,6 @@ def copy_remote(src, dst, overwrite=False):
     """
     Allows us to copy a file from local to remote or vice versa
     """
-    from tensorflow.io import gfile
     return gfile.copy(src, dst, overwrite)
 
 
@@ -47,9 +43,7 @@ def open_remote(path, mode='r', buffering=-1, encoding=None, newline=None, close
     with open_remote('gs://.....', mode='w+') as f:
         do something with the file f, whether or not we have local access to it
     """
-    # Conditional import
     if is_remote_path(path):
-        from tensorflow.io import gfile
         return gfile.GFile(path, mode=mode)
     return open(path, mode, buffering=buffering, encoding=encoding, newline=newline, closefd=closefd, opener=opener)
 
@@ -58,9 +52,7 @@ def isdir_remote(path):
     """
     Wrapper to check if remote and local paths are directories
     """
-    # Conditional import
     if is_remote_path(path):
-        from tensorflow.io import gfile
         return gfile.isdir(path)
     return os.path.isdir(path)
 
@@ -69,9 +61,7 @@ def listdir_remote(path):
     """
     Wrapper to list paths in local dirs (alternative to using a glob, I suppose)
     """
-    # Conditional import
     if is_remote_path(path):
-        from tensorflow.io import gfile
         return gfile.listdir(path)
     return os.listdir(path)
 
@@ -80,9 +70,6 @@ def glob_remote(filename):
     """
     Wrapper that provides globs on local and remote paths like `gs://...`
     """
-    # Conditional import
-    from tensorflow.io import gfile
-
     return gfile.glob(filename)
 
 
@@ -91,6 +78,4 @@ def remove_remote(filename):
     Wrapper that can remove_remote local and remote files like `gs://...`
     """
     # Conditional import
-    from tensorflow.io import gfile
-
     return gfile.remove_remote(filename)

--- a/training/deepspeech_training/util/io.py
+++ b/training/deepspeech_training/util/io.py
@@ -13,7 +13,7 @@ def is_remote_path(path):
     Returns True iff the path is one of the remote formats that this
     module supports
     """
-    return path.startswith('gs://') or path.starts_with('hdfs://')
+    return path.startswith('gs://') or path.startswith('hdfs://')
 
 
 def path_exists_remote(path):

--- a/training/deepspeech_training/util/io.py
+++ b/training/deepspeech_training/util/io.py
@@ -34,7 +34,7 @@ def copy_remote(src, dst, overwrite=False):
 
 def open_remote(path, mode='r', buffering=-1, encoding=None, newline=None, closefd=True, opener=None):
     """
-    Wrapper around open_remote() method that can handle remote paths like `gs://...`
+    Wrapper around open() method that can handle remote paths like `gs://...`
     off Google Cloud using Tensorflow's IO helpers.
 
     buffering, encoding, newline, closefd, and opener are ignored for remote files
@@ -75,7 +75,7 @@ def glob_remote(filename):
 
 def remove_remote(filename):
     """
-    Wrapper that can remove_remote local and remote files like `gs://...`
+    Wrapper that can remove local and remote files like `gs://...`
     """
     # Conditional import
     return gfile.remove_remote(filename)

--- a/training/deepspeech_training/util/io.py
+++ b/training/deepspeech_training/util/io.py
@@ -1,10 +1,20 @@
 """
-A set of I/O utils that allow us to open files on remote storage as if they were present locally.
+A set of I/O utils that allow us to open files on remote storage as if they were present locally and access
+into HDFS storage using Tensorflow's C++ FileStream API.
 Currently only includes wrappers for Google's GCS, but this can easily be expanded for AWS S3 buckets.
 """
 import inspect
 import os
 import sys
+
+
+def is_remote_path(path):
+    """
+    Returns True iff the path is one of the remote formats that this
+    module supports
+    """
+    return path.startswith('gs://') or path.starts_with('hdfs://')
+
 
 def path_exists_remote(path):
     """
@@ -12,10 +22,18 @@ def path_exists_remote(path):
     `gs://...`
     """
     # Conditional import
-    if path.startswith("gs://"):
+    if is_remote_path(path):
         from tensorflow.io import gfile
         return gfile.exists(path)
     return os.path.exists(path)
+
+
+def copy_remote(src, dst, overwrite=False):
+    """
+    Allows us to copy a file from local to remote or vice versa
+    """
+    from tensorflow.io import gfile
+    return gfile.copy(src, dst, overwrite)
 
 
 def open_remote(path, mode):
@@ -28,7 +46,7 @@ def open_remote(path, mode):
         do something with the file f, whether or not we have local access to it
     """
     # Conditional import
-    if path.startswith("gs://"):
+    if is_remote_path(path):
         from tensorflow.io import gfile
         return gfile.GFile(path, mode=mode)
     return open_remote(path, mode)
@@ -39,7 +57,7 @@ def isdir_remote(path):
     Wrapper to check if remote and local paths are directories
     """
     # Conditional import
-    if path.startswith("gs://"):
+    if is_remote_path(path):
         from tensorflow.io import gfile
         return gfile.isdir(path)
     return os.path.isdir(path)
@@ -50,7 +68,7 @@ def listdir_remote(path):
     Wrapper to list paths in local dirs (alternative to using a glob, I suppose)
     """
     # Conditional import
-    if path.startswith("gs://"):
+    if is_remote_path(path):
         from tensorflow.io import gfile
         return gfile.listdir(path)
     return os.listdir(path)

--- a/training/deepspeech_training/util/sample_collections.py
+++ b/training/deepspeech_training/util/sample_collections.py
@@ -18,6 +18,7 @@ from .audio import (
     get_audio_type_from_extension,
     write_wav
 )
+from .io import open_remote
 
 BIG_ENDIAN = 'big'
 INT_SIZE = 4
@@ -80,7 +81,7 @@ def load_sample(filename, label=None):
     audio_type = get_audio_type_from_extension(ext)
     if audio_type is None:
         raise ValueError('Unknown audio type extension "{}"'.format(ext))
-    with open(filename, 'rb') as audio_file:
+    with open_remote(filename, 'rb') as audio_file:
         if label is None:
             return Sample(audio_type, audio_file.read(), sample_id=filename)
         return LabeledSample(audio_type, audio_file.read(), label, sample_id=filename)
@@ -119,7 +120,7 @@ class DirectSDBWriter:
             raise ValueError('Audio type "{}" not supported'.format(audio_type))
         self.audio_type = audio_type
         self.bitrate = bitrate
-        self.sdb_file = open(sdb_filename, 'wb', buffering=buffering)
+        self.sdb_file = open_remote(sdb_filename, 'wb', buffering=buffering)
         self.offsets = []
         self.num_samples = 0
 
@@ -215,7 +216,7 @@ class SDB:  # pylint: disable=too-many-instance-attributes
         """
         self.sdb_filename = sdb_filename
         self.id_prefix = sdb_filename if id_prefix is None else id_prefix
-        self.sdb_file = open(sdb_filename, 'rb', buffering=REVERSE_BUFFER_SIZE if reverse else buffering)
+        self.sdb_file = open_remote(sdb_filename, 'rb', buffering=REVERSE_BUFFER_SIZE if reverse else buffering)
         self.offsets = []
         if self.sdb_file.read(len(MAGIC)) != MAGIC:
             raise RuntimeError('No Sample Database')
@@ -345,7 +346,7 @@ class CSVWriter:  # pylint: disable=too-many-instance-attributes
         self.labeled = labeled
         if labeled:
             fieldnames.append('transcript')
-        self.csv_file = open(csv_filename, 'w', encoding='utf-8', newline='')
+        self.csv_file = open_remote(csv_filename, 'w', encoding='utf-8', newline='')
         self.csv_writer = csv.DictWriter(self.csv_file, fieldnames=fieldnames)
         self.csv_writer.writeheader()
         self.counter = 0
@@ -399,7 +400,7 @@ class TarWriter:  # pylint: disable=too-many-instance-attributes
         include : str[]
             List of files to include into tar root.
         """
-        self.tar = tarfile.open(tar_filename, 'w:gz' if gz else 'w')
+        self.tar = tarfile.open_remote(tar_filename, 'w:gz' if gz else 'w')
         samples_dir = tarfile.TarInfo('samples')
         samples_dir.type = tarfile.DIRTYPE
         self.tar.addfile(samples_dir)
@@ -499,7 +500,7 @@ class CSV(SampleList):
         """
         rows = []
         csv_dir = Path(csv_filename).parent
-        with open(csv_filename, 'r', encoding='utf8') as csv_file:
+        with open_remote(csv_filename, 'r', encoding='utf8') as csv_file:
             reader = csv.DictReader(csv_file)
             if 'transcript' in reader.fieldnames:
                 if labeled is None:

--- a/training/deepspeech_training/util/sample_collections.py
+++ b/training/deepspeech_training/util/sample_collections.py
@@ -72,13 +72,11 @@ class PackedSample:
         self.label = label
 
     def unpack(self):
-        print("Unpacking sample: %s" % self.filename)
         with open_remote(self.filename, 'rb') as audio_file:
             data = audio_file.read()
         if self.label is None:
             s = Sample(self.audio_type, data, sample_id=self.filename)
         s = LabeledSample(self.audio_type, data, self.label, sample_id=self.filename)
-        print("unpacked!")
         return s
 
 def load_sample(filename, label=None):
@@ -99,7 +97,6 @@ def load_sample(filename, label=None):
     util.sample_collections.PackedSample, a wrapper object, on which calling unpack() will return
         util.audio.Sample instance if label is None, else util.sample_collections.LabeledSample instance
     """
-    print("loading sample!")
     ext = os.path.splitext(filename)[1].lower()
     audio_type = get_audio_type_from_extension(ext)
     if audio_type is None:

--- a/training/deepspeech_training/util/sample_collections.py
+++ b/training/deepspeech_training/util/sample_collections.py
@@ -350,9 +350,9 @@ class CSVWriter:  # pylint: disable=too-many-instance-attributes
         labeled : bool or None
             If True: Writes labeled samples (util.sample_collections.LabeledSample) only.
             If False: Ignores transcripts (if available) and writes (unlabeled) util.audio.Sample instances.
+        
+        Currently only works with local files (not gs:// or hdfs://...)
         """
-
-        # TODO: This all breaks with remote paths
         self.csv_filename = Path(csv_filename)
         self.csv_base_dir = self.csv_filename.parent.resolve().absolute()
         self.set_name = self.csv_filename.stem
@@ -400,7 +400,7 @@ class CSVWriter:  # pylint: disable=too-many-instance-attributes
 
 
 class TarWriter:  # pylint: disable=too-many-instance-attributes
-    """Sample collection writer for writing a CSV data-set and all its referenced WAV samples to a tar file"""
+    """Sample collection writer for writing a CSV data-set and all its referenced WAV samples to a tar file."""
     def __init__(self,
                  tar_filename,
                  gz=False,
@@ -418,8 +418,10 @@ class TarWriter:  # pylint: disable=too-many-instance-attributes
             If False: Ignores transcripts (if available) and writes (unlabeled) util.audio.Sample instances.
         include : str[]
             List of files to include into tar root.
+
+        Currently only works with local files (not gs:// or hdfs://...)
         """
-        self.tar = tarfile.open_remote(tar_filename, 'w:gz' if gz else 'w')
+        self.tar = tarfile.open(tar_filename, 'w:gz' if gz else 'w')
         samples_dir = tarfile.TarInfo('samples')
         samples_dir.type = tarfile.DIRTYPE
         self.tar.addfile(samples_dir)

--- a/training/deepspeech_training/util/sample_collections.py
+++ b/training/deepspeech_training/util/sample_collections.py
@@ -334,6 +334,8 @@ class CSVWriter:  # pylint: disable=too-many-instance-attributes
             If True: Writes labeled samples (util.sample_collections.LabeledSample) only.
             If False: Ignores transcripts (if available) and writes (unlabeled) util.audio.Sample instances.
         """
+
+        # TODO: This all breaks with remote paths
         self.csv_filename = Path(csv_filename)
         self.csv_base_dir = self.csv_filename.parent.resolve().absolute()
         self.set_name = self.csv_filename.stem

--- a/training/deepspeech_training/util/taskcluster.py
+++ b/training/deepspeech_training/util/taskcluster.py
@@ -14,6 +14,7 @@ import sys
 
 from pkg_resources import parse_version
 
+from .io import isdir_remote, open_remote
 
 DEFAULT_SCHEMES = {
     'deepspeech': 'https://community-tc.services.mozilla.com/api/index/v1/task/project.deepspeech.deepspeech.native_client.%(branch_name)s.%(arch_string)s/artifacts/public/%(artifact_name)s',
@@ -48,7 +49,7 @@ def maybe_download_tc(target_dir, tc_url, progress=True):
     except OSError as e:
         if e.errno != errno.EEXIST:
             raise e
-    assert os.path.isdir(os.path.dirname(target_dir))
+    assert isdir_remote(os.path.dirname(target_dir))
 
     tc_filename = os.path.basename(tc_url)
     target_file = os.path.join(target_dir, tc_filename)
@@ -61,7 +62,7 @@ def maybe_download_tc(target_dir, tc_url, progress=True):
         print('File already exists: %s' % target_file)
 
     if is_gzip:
-        with open(target_file, "r+b") as frw:
+        with open_remote(target_file, "r+b") as frw:
             decompressed = gzip.decompress(frw.read())
             frw.seek(0)
             frw.write(decompressed)
@@ -75,7 +76,7 @@ def maybe_download_tc_bin(**kwargs):
     os.chmod(final_file, final_stat.st_mode | stat.S_IEXEC)
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open_remote(os.path.join(os.path.dirname(__file__), fname)).read()
 
 def main():
     parser = argparse.ArgumentParser(description='Tooling to ease downloading of components from TaskCluster.')

--- a/training/deepspeech_training/util/taskcluster.py
+++ b/training/deepspeech_training/util/taskcluster.py
@@ -14,7 +14,7 @@ import sys
 
 from pkg_resources import parse_version
 
-from .io import isdir_remote, open_remote
+from .io import isdir_remote, open_remote, is_remote_path
 
 DEFAULT_SCHEMES = {
     'deepspeech': 'https://community-tc.services.mozilla.com/api/index/v1/task/project.deepspeech.deepspeech.native_client.%(branch_name)s.%(arch_string)s/artifacts/public/%(artifact_name)s',
@@ -43,13 +43,13 @@ def maybe_download_tc(target_dir, tc_url, progress=True):
 
     assert target_dir is not None
 
-    target_dir = os.path.abspath(target_dir)
-    try:
-        os.makedirs(target_dir)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            raise e
-    assert isdir_remote(os.path.dirname(target_dir))
+    if not is_remote_path(target_dir):
+        try:
+            os.makedirs(target_dir)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise e
+        assert os.path.isdir(os.path.dirname(target_dir))
 
     tc_filename = os.path.basename(tc_url)
     target_file = os.path.join(target_dir, tc_filename)

--- a/training/deepspeech_training/util/taskcluster.py
+++ b/training/deepspeech_training/util/taskcluster.py
@@ -76,7 +76,7 @@ def maybe_download_tc_bin(**kwargs):
     os.chmod(final_file, final_stat.st_mode | stat.S_IEXEC)
 
 def read(fname):
-    return open_remote(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 def main():
     parser = argparse.ArgumentParser(description='Tooling to ease downloading of components from TaskCluster.')


### PR DESCRIPTION
Offering this up as a PR in case it's useful to more people than just me.

This refactors the training code to use a set of I/O helpers that allow for remote file access, right now using TensorFlow's GFIle API, allowing us to pass in files like `gs://my-bucket/my/path` or `hdfs://...`. This can be extended to AWS `s3://...` paths relatively easily.

Most of the refactoring is fairly straightforward. Things get a little bit more complicated with `AudioFile`, since you pass a local file to sox for the conversion. I've just wrapped that into a copy in a tmpfile, since I assume the conversion overhead prevails here and there was a reason for doing things this way.

I did this because I wanted to bring in datasets that I have on distributed storage and train on GCP AI platform, but I'd also be curious in your feedback in how you expect this to perform so that I/O doesn't become the bottleneck. It seems like pre-fetching for training is done by `apply_sample_augmentations` with the default value of `process_ahead=2 * batch_size`. Am I following this correctly? For network I/O vs. just having a local SSD with all the data, I might go a little bit higher than that, but even then it seems like the way this is implemented, we could still end up in an I/O-bound situation…