### PR TITLE
Changes misleading error message for wrong lm.binary

### DIFF
--- a/native_client/deepspeech.h
+++ b/native_client/deepspeech.h
@@ -69,7 +69,7 @@ typedef struct Metadata {
   APPLY(DS_ERR_INVALID_SCORER,          0x2002, "Invalid scorer file.") \
   APPLY(DS_ERR_MODEL_INCOMPATIBLE,      0x2003, "Incompatible model.") \
   APPLY(DS_ERR_SCORER_NOT_ENABLED,      0x2004, "External scorer is not enabled.") \
-  APPLY(DS_ERR_SCORER_UNREADABLE,       0x2005, "Could not read scorer file.") \
+  APPLY(DS_ERR_SCORER_UNREADABLE,       0x2005, "Could not read language model (lm.binary) file.") \
   APPLY(DS_ERR_SCORER_INVALID_LM,       0x2006, "Could not recognize language model header in scorer.") \
   APPLY(DS_ERR_SCORER_NO_TRIE,          0x2007, "Reached end of scorer file before loading vocabulary trie.") \
   APPLY(DS_ERR_SCORER_INVALID_TRIE,     0x2008, "Invalid magic in trie header.") \


### PR DESCRIPTION
The error message for an unreadable lm binary file is misleading. We just had a user [how wanted to build a scorer](https://discourse.mozilla.org/t/error-while-generating-own-scorer/70945/4) with `generate_scorer `and got the message "Could not read the scorer file." But he is missing the right lm.binary file. It would therefore be better to state that.

@reuben I am pretty sure,  `lm_load ` always loads the lm binary in the scorer, so I am unsure whether to change the message here or to catch the error and change it on the fly. What do you think?