### PR TITLE
Conditional msg for missing lm.binary added

### DIFF
--- a/native_client/generate_scorer_package.cpp
+++ b/native_client/generate_scorer_package.cpp
@@ -68,7 +68,8 @@ create_package(absl::optional<string> alphabet_path,
     int err = scorer.load_lm(lm_path);
     if (err != DS_ERR_SCORER_NO_TRIE) {
         cerr << "Error loading language model file: "
-             << DS_ErrorCodeToErrorMessage(err) << "\n";
+             << (err == DS_ERR_SCORER_UNREADABLE ? "Can't open binary LM file." : DS_ErrorCodeToErrorMessage(err))
+             << "\n";
         return 1;
     }
     scorer.fill_dictionary(words);


### PR DESCRIPTION
The error message for an unreadable lm binary file is misleading. We just had a user [who wanted to build a scorer](https://discourse.mozilla.org/t/error-while-generating-own-scorer/70945/4) with `generate_scorer` and got the message "Could not read the scorer file." But he is missing the right lm.binary file. It would therefore be better to state that.

@reuben I changed the output to change the msg in case it the the 
 `DS_ERR_SCORER_UNREADABLE` message. And I haven't been coding C++ for a long time, hope that's fine with you.