### PR TITLE
Update 404ing link to the eigen3 library - bitbucket to gitlab

### DIFF
--- a/native_client/kenlm/lm/interpolate/CMakeLists.txt
+++ b/native_client/kenlm/lm/interpolate/CMakeLists.txt
@@ -65,6 +65,6 @@ else()
   message(WARNING "Not building interpolation. Eigen3 was not found.")
   message(STATUS "To install Eigen3 in your home directory, copy paste this:\n"
       "export EIGEN3_ROOT=$HOME/eigen-eigen-07105f7124f9\n"
-      "(cd $HOME; wget -O - https://bitbucket.org/eigen/eigen/get/3.2.8.tar.bz2 |tar xj)\n"
+      "(cd $HOME; wget -O - https://gitlab.com/libeigen/eigen/-/archive/3.3.8/eigen-3.3.8.tar.bz2 |tar xj)\n"
       "rm CMakeCache.txt\n")
 endif()


### PR DESCRIPTION
I raised this PR because of an `eigen3` warning received while I was building the training Docker image. 

These are the steps I followed in getting the warning and resolving it. 

## Error while building the DeepSpeech Docker image 

```
-- Could NOT find LibLZMA (missing: LIBLZMA_INCLUDE_DIR LIBLZMA_LIBRARY LIBLZMA_HAS_AUTO_DECODER LIBLZMA_HAS_EASY_ENCODER LIBLZMA_HAS_LZMA_PRESET) 
-- Could NOT find Eigen3 (missing: EIGEN3_INCLUDE_DIR EIGEN3_VERSION_OK) (Required is at least version "2.91.0")
CMake Warning at lm/interpolate/CMakeLists.txt:66 (message):
  Not building interpolation.  Eigen3 was not found.


-- To install Eigen3 in your home directory, copy paste this:
export EIGEN3_ROOT=$HOME/eigen-eigen-07105f7124f9
(cd $HOME; wget -O - https://bitbucket.org/eigen/eigen/get/3.2.8.tar.bz2 |tar xj)
rm CMakeCache.txt
```

I attempted the `bash` instructions given, which yielded: 

```
(deepspeech-train-venv) kathyreid@3ai-precision5500:~/deepspeech-train-venv/DeepSpeech$ export EIGEN3_ROOT=$HOME/eigen-eigen-07105f7124f9
(deepspeech-train-venv) kathyreid@3ai-precision5500:~/deepspeech-train-venv/DeepSpeech$ (cd $HOME; wget -O - https://bitbucket.org/eigen/eigen/get/3.2.8.tar.bz2 |tar xj)
--2020-12-30 15:03:24--  https://bitbucket.org/eigen/eigen/get/3.2.8.tar.bz2
Resolving bitbucket.org (bitbucket.org)... 104.192.141.1, 2406:da00:ff00::22c3:9b0a, 2406:da00:ff00::22c5:2ef4, ...
Connecting to bitbucket.org (bitbucket.org)|104.192.141.1|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2020-12-30 15:03:26 ERROR 404: Not Found.


bzip2: Compressed file ends unexpectedly;
	perhaps it is corrupted?  *Possible* reason follows.
bzip2: Inappropriate ioctl for device
	Input file = (stdin), output file = (stdout)

It is possible that the compressed file(s) have become corrupted.
You can use the -tvv option to test integrity of such files.

You can use the `bzip2recover' program to attempt to recover
data from undamaged sections of corrupted files.

tar: Child returned status 2
tar: Error is not recoverable: exiting now
```

Figured that `eigen3` had moved away from bitbucket to another version control platform, found it on Gitlab. Substituted Gitlab tarball instead as follows: 

```
(deepspeech-train-venv) kathyreid@3ai-precision5500:~$ (cd $HOME; wget -O - https://gitlab.com/libeigen/eigen/-/archive/3.3.8/eigen-3.3.8.tar.bz2 |tar xj)
--2020-12-30 15:45:34--  https://gitlab.com/libeigen/eigen/-/archive/3.3.8/eigen-3.3.8.tar.bz2
Resolving gitlab.com (gitlab.com)... 172.65.251.78, 2606:4700:90:0:f22e:fbec:5bed:a9b9
Connecting to gitlab.com (gitlab.com)|172.65.251.78|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [application/octet-stream]
Saving to: 'STDOUT’

-                                        [       <=>                                                             ]   1.59M  1.03MB/s    in 1.5s    

2020-12-30 15:45:36 (1.03 MB/s) - written to stdout [1667794]

```

Raising PR in case other folks come across the warning, and then hit a 404. 

Best, Kathy