### PR TITLE
Added sox dependency in Dockerfile.train

### DIFF
--- a/Dockerfile.train.tmpl
+++ b/Dockerfile.train.tmpl
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libbz2-dev \
         locales \
         python3-venv \
+	sox \
         unzip \
         wget
 


### PR DESCRIPTION
Added sox in Dockerfile to prevent import `bin/import_cv2.py` from failing inside the container.
The script runs the `soxi` command which is provided by this dependency.