### PR TITLE
Use a separate task property for getting artifacts of tasks depended on

### DIFF
--- a/taskcluster/tc-all-utils.sh
+++ b/taskcluster/tc-all-utils.sh
@@ -66,7 +66,7 @@ set_ldc_sample_filename()
 get_dependency_url()
 {
   local _file=$1
-  all_deps="$(curl -s https://community-tc.services.mozilla.com/api/queue/v1/task/${TASK_ID} | python -c 'import json; import sys; print(" ".join(json.loads(sys.stdin.read())["dependencies"]));')"
+  all_deps="$(curl -s https://community-tc.services.mozilla.com/api/queue/v1/task/${TASK_ID} | python -c 'import json; import sys; print(" ".join(json.loads(sys.stdin.read())["payload"]["artifact_dependencies"]));')"
 
   for dep in ${all_deps}; do
     local has_artifact=$(curl -s https://community-tc.services.mozilla.com/api/queue/v1/task/${dep}/artifacts | python -c 'import json; import sys; has_artifact = True in [ e["name"].find("'${_file}'") > 0 for e in json.loads(sys.stdin.read())["artifacts"] ]; print(has_artifact)')
@@ -77,6 +77,8 @@ get_dependency_url()
   done;
 
   echo ""
+  # This should not be reached, it means we could not find the needed dependency URL
+  exit 1
 }
 
 download_dependency_file()

--- a/taskcluster/tc-dotnet-utils.sh
+++ b/taskcluster/tc-dotnet-utils.sh
@@ -17,8 +17,8 @@ install_nuget()
   mkdir -p "${TASKCLUSTER_TMP_DIR}/repo/"
   mkdir -p "${TASKCLUSTER_TMP_DIR}/ds/"
 
-  nuget_pkg_url=$(get_dep_nuget_pkg_url "${nuget}")
-  console_pkg_url=$(get_dep_nuget_pkg_url "DeepSpeechConsole.exe")
+  nuget_pkg_url=$(get_dependency_url "${nuget}")
+  console_pkg_url=$(get_dependency_url "DeepSpeechConsole.exe")
 
   ${WGET} -O - "${nuget_pkg_url}" | gunzip > "${TASKCLUSTER_TMP_DIR}/${PROJECT_NAME}.${DS_VERSION}.nupkg"
   ${WGET} -O - "${console_pkg_url}" | gunzip > "${TASKCLUSTER_TMP_DIR}/ds/DeepSpeechConsole.exe"
@@ -42,23 +42,4 @@ install_nuget()
   ls -hal ${TASKCLUSTER_TMP_DIR}/ds/
 
   export PATH=${TASKCLUSTER_TMP_DIR}/ds/:$PATH
-}
-
-# Will inspect this task's dependencies for one that provides a matching NuGet package
-get_dep_nuget_pkg_url()
-{
-  local deepspeech_pkg=$1
-  local all_deps="$(curl -s https://community-tc.services.mozilla.com/api/queue/v1/task/${TASK_ID} | python -c 'import json; import sys; print(" ".join(json.loads(sys.stdin.read())["dependencies"]));')"
-
-  for dep in ${all_deps}; do
-    local has_artifact=$(curl -s https://community-tc.services.mozilla.com/api/queue/v1/task/${dep}/artifacts | python -c 'import json; import sys; has_artifact = True in [ e["name"].find("'${deepspeech_pkg}'") > 0 for e in json.loads(sys.stdin.read())["artifacts"] ]; print(has_artifact)')
-    if [ "${has_artifact}" = "True" ]; then
-      echo "https://community-tc.services.mozilla.com/api/queue/v1/task/${dep}/artifacts/public/${deepspeech_pkg}"
-      exit 0
-    fi;
-  done;
-
-  echo ""
-  # This should not be reached, otherwise it means we could not find a matching nodejs package
-  exit 1
 }

--- a/taskcluster/test-android-opt-base.tyml
+++ b/taskcluster/test-android-opt-base.tyml
@@ -19,6 +19,11 @@ then:
     maxRunTime: { $eval: to_int(build.maxRunTime) }
     image: "ubuntu:18.04"
 
+    artifact_dependencies:
+      $map: { $eval: build.dependencies }
+      each(b):
+        $eval: as_slugid(b)
+
     capabilities:
       devices:
         kvm: true

--- a/taskcluster/test-armbian-opt-base.tyml
+++ b/taskcluster/test-armbian-opt-base.tyml
@@ -17,6 +17,11 @@ then:
     maxRunTime: { $eval: to_int(build.maxRunTime) }
     image: "arm64v8/debian:buster-20200422"
 
+    artifact_dependencies:
+      $map: { $eval: build.dependencies }
+      each(b):
+        $eval: as_slugid(b)
+
     env:
       $let:
         training: { $eval: as_slugid(build.test_model_task) }

--- a/taskcluster/test-darwin-opt-base.tyml
+++ b/taskcluster/test-darwin-opt-base.tyml
@@ -20,6 +20,11 @@ then:
   payload:
     maxRunTime: { $eval: to_int(build.maxRunTime) }
 
+    artifact_dependencies:
+      $map: { $eval: build.dependencies }
+      each(b):
+        $eval: as_slugid(b)
+
     env:
       $let:
         training: { $eval: as_slugid(build.test_model_task) }

--- a/taskcluster/test-linux-opt-base.tyml
+++ b/taskcluster/test-linux-opt-base.tyml
@@ -17,6 +17,11 @@ then:
     maxRunTime: { $eval: to_int(build.maxRunTime) }
     image: ${build.docker_image}
 
+    artifact_dependencies:
+      $map: { $eval: build.dependencies }
+      each(b):
+        $eval: as_slugid(b)
+
     env:
       $let:
         training: { $eval: as_slugid(build.test_model_task) }

--- a/taskcluster/test-linux-opt-tag-base.tyml
+++ b/taskcluster/test-linux-opt-tag-base.tyml
@@ -17,6 +17,11 @@ then:
     maxRunTime: { $eval: to_int(build.maxRunTime) }
     image: ${build.docker_image}
 
+    artifact_dependencies:
+      $map: { $eval: build.dependencies }
+      each(b):
+        $eval: as_slugid(b)
+
     env:
       $let:
         training: { $eval: as_slugid(build.test_model_task) }

--- a/taskcluster/test-raspbian-opt-base.tyml
+++ b/taskcluster/test-raspbian-opt-base.tyml
@@ -17,6 +17,11 @@ then:
     maxRunTime: { $eval: to_int(build.maxRunTime) }
     image: "balenalib/rpi-raspbian:buster-20200429"
 
+    artifact_dependencies:
+      $map: { $eval: build.dependencies }
+      each(b):
+        $eval: as_slugid(b)
+
     env:
       $let:
         training: { $eval: as_slugid(build.test_model_task) }

--- a/taskcluster/test-win-cuda-opt-base.tyml
+++ b/taskcluster/test-win-cuda-opt-base.tyml
@@ -16,6 +16,11 @@ then:
   payload:
     maxRunTime: { $eval: to_int(build.maxRunTime) }
 
+    artifact_dependencies:
+      $map: { $eval: build.dependencies }
+      each(b):
+        $eval: as_slugid(b)
+
     env:
       $let:
         training: { $eval: as_slugid(build.test_model_task) }

--- a/taskcluster/test-win-opt-base.tyml
+++ b/taskcluster/test-win-opt-base.tyml
@@ -16,6 +16,11 @@ then:
   payload:
     maxRunTime: { $eval: to_int(build.maxRunTime) }
 
+    artifact_dependencies:
+      $map: { $eval: build.dependencies }
+      each(b):
+        $eval: as_slugid(b)
+
     env:
       $let:
         training: { $eval: as_slugid(build.test_model_task) }


### PR DESCRIPTION
This is a convenience change for manually iterating on tasks in the TaskCluster UI. The "edit task" UI removes the tasks' dependencies, which means when editing a test task you need to manually reinsert the dependencies every time. This separates the dependency for scheduling purposes from the dependency for downloading artifacts, so that the latter is kept in the "edit task" UI and one can just edit the payload as needed to develop/debug/iterate.