### PR TITLE
Pull in CUDA to the Dockerfile template used for training

### DIFF
--- a/Dockerfile.train.tmpl
+++ b/Dockerfile.train.tmpl
@@ -1,5 +1,9 @@
 # Please refer to the TRAINING documentation, "Basic Dockerfile for training"
 
+# Pull in CUDA so that the GPU can be accessed from within the Docker container 
+FROM nvidia/cuda:10.2-base
+CMD nvidia-smi
+
 FROM tensorflow/tensorflow:1.15.4-gpu-py3
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
To allow the GPU(s) of the host to be exposed to the Docker container. Without this, the GPUs are not exposed to the Docker container and Docker trains CPU-only. 

From: https://blog.roboflow.com/use-the-gpu-in-docker/

I built a Docker image with these lines, and spawned a container and was able to use `--gpus all` when spawning a container. 
That is, I've tested this change.