### PR TITLE
Docu building ctc decoder on unsupported architecture

### DIFF
--- a/doc/BUILDING.rst
+++ b/doc/BUILDING.rst
@@ -327,3 +327,33 @@ much performance gains do you get in your applications, how you had to change
 the model to make it work with a delegate, etc.
 
 See :ref:`the support / contact details <support>`
+
+
+Building CTC Decoder for training on unsupported platforms
+----------------------------------------------------------
+Alongside linux on x86 and arm, macOS and windows there also exists a lot of
+other architectures which are not offically supported by the DeepSpeech team.
+
+Nevertheless, we offer some hits for other architectures provided by users.
+If you have problems, ask in our `discourse <https://discourse.mozilla.org/>`.
+
+Feedback on improving this section or usage on other architectures is welcome.
+
+Since, * `SWIG >= 3.0.12 <http://www.swig.org/>`_ does not include our patches please use
+https://github.com/lissyx/swig/tree/taskcluster for building SWIG from source.
+
+You can supply your prebuild SWIG using ``SWIG_DIST_URL``
+
+Moreover you may have to change ``PYTHON_PLATFORM_NAME`` corresponding to your platform.
+
+.. code-block::
+
+    # PowerPC (ppc64le)
+    PYTHON_PLATFORM_NAME="--plat-name linux_ppc64le"
+
+
+Complete build command:
+
+.. code-block::
+
+    SWIG_DIST_URL=[...] PYTHON_PLATFORM_NAME=[...] make bindings

--- a/doc/BUILDING.rst
+++ b/doc/BUILDING.rst
@@ -153,7 +153,7 @@ To build the ``ds_ctcdecoder`` package, you'll need the general requirements lis
 Building CTC Decoder for training on unsupported platforms
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We only support building CTC Decoder on x86 and arm architectures.
+We only support building CTC Decoder on x86-64 architecture.
 However, we offer some hints on building the CTC decoder on other
 architectures, and you might find some help in our `discourse <https://discourse.mozilla.org/>`.
 

--- a/doc/BUILDING.rst
+++ b/doc/BUILDING.rst
@@ -149,6 +149,37 @@ To build the ``ds_ctcdecoder`` package, you'll need the general requirements lis
    make bindings NUM_PROCESSES=8
    pip install dist/*.whl
 
+
+Building CTC Decoder for training on unsupported platforms
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We only support building CTC Decoder on x86 and arm architectures.
+However, we offer some hints on building the CTC decoder on other
+architectures, and you might find some help in our `discourse <https://discourse.mozilla.org/>`.
+
+Feedback on improving this section or usage on other architectures is welcome.
+
+First, you need to build SWIG from scratch.
+Since `SWIG >= 3.0.12 <http://www.swig.org/>`_ does not include our patches please use
+https://github.com/lissyx/swig/tree/taskcluster for building SWIG from source.
+
+You can supply your prebuild SWIG using ``SWIG_DIST_URL``
+
+Moreover you may have to change ``PYTHON_PLATFORM_NAME`` corresponding to your platform.
+
+.. code-block::
+
+    # PowerPC (ppc64le)
+    PYTHON_PLATFORM_NAME="--plat-name linux_ppc64le"
+
+
+Complete build command:
+
+.. code-block::
+
+    SWIG_DIST_URL=[...] PYTHON_PLATFORM_NAME=[...] make bindings
+    pip install dist/*.whl
+
 Cross-building
 --------------
 
@@ -327,33 +358,3 @@ much performance gains do you get in your applications, how you had to change
 the model to make it work with a delegate, etc.
 
 See :ref:`the support / contact details <support>`
-
-
-Building CTC Decoder for training on unsupported platforms
-----------------------------------------------------------
-Alongside linux on x86 and arm, macOS and windows there also exists a lot of
-other architectures which are not offically supported by the DeepSpeech team.
-
-Nevertheless, we offer some hits for other architectures provided by users.
-If you have problems, ask in our `discourse <https://discourse.mozilla.org/>`.
-
-Feedback on improving this section or usage on other architectures is welcome.
-
-Since, * `SWIG >= 3.0.12 <http://www.swig.org/>`_ does not include our patches please use
-https://github.com/lissyx/swig/tree/taskcluster for building SWIG from source.
-
-You can supply your prebuild SWIG using ``SWIG_DIST_URL``
-
-Moreover you may have to change ``PYTHON_PLATFORM_NAME`` corresponding to your platform.
-
-.. code-block::
-
-    # PowerPC (ppc64le)
-    PYTHON_PLATFORM_NAME="--plat-name linux_ppc64le"
-
-
-Complete build command:
-
-.. code-block::
-
-    SWIG_DIST_URL=[...] PYTHON_PLATFORM_NAME=[...] make bindings


### PR DESCRIPTION
As mentioned in  #3505 and #3379 I documented how to build ctc decoder on ppc64le