### PR TITLE
Convert Audio on the Fly

### DIFF
--- a/training/deepspeech_training/util/audio.py
+++ b/training/deepspeech_training/util/audio.py
@@ -174,6 +174,10 @@ def convert_audio(src_audio_path, dst_audio_path, file_type=None, audio_format=D
 
 
 class AudioFile:
+    """
+    Audio data file wrapper that ensures that the file is loaded with the correct sample rate, channels,
+    and width, and converts the file on the fly otherwise.
+    """
     def __init__(self, audio_path, as_path=False, audio_format=DEFAULT_FORMAT):
         self.audio_path = audio_path
         self.audio_format = audio_format
@@ -199,8 +203,8 @@ class AudioFile:
         # If the format isn't right, copy the file to local tmp dir and do the conversion on disk
         if is_remote_path(self.audio_path):
             _, self.tmp_src_file_path = tempfile.mkstemp(suffix='.wav')
-            copy_remote(self.audio_path, self.tmp_src_file_path)
-            self.audio_path = self.tmp_file_path
+            copy_remote(self.audio_path, self.tmp_src_file_path, True)
+            self.audio_path = self.tmp_src_file_path
 
         _, self.tmp_file_path = tempfile.mkstemp(suffix='.wav')
         convert_audio(self.audio_path, self.tmp_file_path, file_type='wav', audio_format=self.audio_format)

--- a/training/deepspeech_training/util/audio.py
+++ b/training/deepspeech_training/util/audio.py
@@ -207,6 +207,8 @@ class AudioFile:
             self.audio_path = self.tmp_src_file_path
 
         _, self.tmp_file_path = tempfile.mkstemp(suffix='.wav')
+        print("Performing sox conversion on temporary file for %s" % self.audio_path)
+        # Sox will complain that the output file already exists, but it will willingly overwrite it.
         convert_audio(self.audio_path, self.tmp_file_path, file_type='wav', audio_format=self.audio_format)
         if self.as_path:
             return self.tmp_file_path

--- a/training/deepspeech_training/util/sample_collections.py
+++ b/training/deepspeech_training/util/sample_collections.py
@@ -15,6 +15,7 @@ from .audio import (
     AUDIO_TYPE_OPUS,
     SERIALIZABLE_AUDIO_TYPES,
     get_loadable_audio_type_from_extension,
+    AudioFile,
     write_wav
 )
 from .io import open_remote, is_remote_path
@@ -71,8 +72,11 @@ class PackedSample:
         self.label = label
 
     def unpack(self):
-        with open_remote(self.filename, 'rb') as audio_file:
-            data = audio_file.read()
+        # Wrapped in AudioFile to get conversion to the correct sample rate, channels, and width
+        # on the fly if necessary
+        with AudioFile(self.filename, as_path=True) as path:
+            with open_remote(path, 'rb') as audio_file:
+                data = audio_file.read()
         if self.label is None:
             s = Sample(self.audio_type, data, sample_id=self.filename)
         s = LabeledSample(self.audio_type, data, self.label, sample_id=self.filename)


### PR DESCRIPTION
This uses the `AudioFile` wrapper during sample to get conversion to the correct sample rate, channels, and width on the fly if necessary. It's still more efficient to perform this before training, but this makes it more convenient when adding data with e.g. a different sample rate on the fly.

Let me know what you think about this. Of course, if the rest of the training code could handle differing sample rates etc. on the fly, that would alleviate the need for this. Saw some TODOs on that front in the code, but figured it wasn't done.

Irrespective of the other two commits, I think https://github.com/mozilla/DeepSpeech/commit/e4bb082f8051d02be386d31b890e618acf5729b6 should get applied as that is just a bug fix for something that I broke earlier while implementing the remote training I/O stuff. I was surprised to see that `AudioFile` was actually not really being used anywhere except when splitting audio files for dataset prep, so was wondering why.