### PR TITLE
Fix incompatible Swift module error

### DIFF
--- a/native_client/swift/deepspeech_ios.xcodeproj/project.pbxproj
+++ b/native_client/swift/deepspeech_ios.xcodeproj/project.pbxproj
@@ -369,6 +369,7 @@
 		505B137624960D550007DADA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
@@ -395,8 +396,8 @@
 					"$(PROJECT_DIR)",
 				);
 				MODULEMAP_FILE = deepspeech_ios/deepspeech_ios.modulemap;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.deepspeech.deepspeech-ios";
 				OTHER_LDFLAGS = "-lstdc++";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.deepspeech.deepspeech-ios";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -408,6 +409,7 @@
 		505B137724960D550007DADA /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
@@ -434,8 +436,8 @@
 					"$(PROJECT_DIR)",
 				);
 				MODULEMAP_FILE = deepspeech_ios/deepspeech_ios.modulemap;
-				PRODUCT_BUNDLE_IDENTIFIER = "org.deepspeech.deepspeech-ios";
 				OTHER_LDFLAGS = "-lstdc++";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.deepspeech.deepspeech-ios";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;

--- a/native_client/swift/deepspeech_ios_test.xcodeproj/xcshareddata/xcschemes/deepspeech_ios_test.xcscheme
+++ b/native_client/swift/deepspeech_ios_test.xcodeproj/xcshareddata/xcschemes/deepspeech_ios_test.xcscheme
@@ -71,13 +71,6 @@
             ReferencedContainer = "container:deepspeech_ios_test.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-         <AdditionalOption
-            key = "NSZombieEnabled"
-            value = "YES"
-            isEnabled = "YES">
-         </AdditionalOption>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
Fixes `module compiled with Swift 5.1.3 cannot be imported by the Swift 5.3.2`. 

Tested by following [these](https://github.com/mozilla/DeepSpeech/pull/3436) instructions.