### PR TITLE
Enable multiple input txts

### DIFF
--- a/data/lm/generate_lm.py
+++ b/data/lm/generate_lm.py
@@ -4,6 +4,8 @@ import io
 import os
 import subprocess
 from collections import Counter
+from itertools import zip_longest
+import shutil
 
 import progressbar
 
@@ -11,67 +13,88 @@ import progressbar
 def convert_and_filter_topk(args):
     """ Convert to lowercase, count word occurrences and save top-k words to a file """
 
-    counter = Counter()
-    data_lower = os.path.join(args.output_dir, "lower.txt.gz")
+    # Loop over multiple input_txt arguments
+    data_lowers = []
+    vocabs = []
+    vocab_str_combined = ""
+    fill = args.top_k[-1] # with multiple input_txt arguments where there are fewer top_k
+                          # arguments, the last top_k will recur for the extra input_txts
+    for input_txt_num, (input_txt_item, top_k_item) in \
+            enumerate(zip_longest(args.input_txt,args.top_k, fillvalue=fill), 1):
 
-    print("\nConverting to lowercase and counting word occurrences ...")
-    with io.TextIOWrapper(
-        io.BufferedWriter(gzip.open(data_lower, "w+")), encoding="utf-8"
-    ) as file_out:
+        print(f"\nProcessing input_txt {input_txt_num} of {len(args.input_txt)}")
+        print(f"  {input_txt_item}")
+        counter = Counter()
+        data_lower = os.path.join(args.output_dir, f"lower_{input_txt_num}.txt.gz")
+        data_lowers.append(data_lower)
 
-        # Open the input file either from input.txt or input.txt.gz
-        _, file_extension = os.path.splitext(args.input_txt)
-        if file_extension == ".gz":
-            file_in = io.TextIOWrapper(
-                io.BufferedReader(gzip.open(args.input_txt)), encoding="utf-8"
-            )
-        else:
-            file_in = open(args.input_txt, encoding="utf-8")
+        print("\nConverting to lowercase and counting word occurrences ...")
+        with io.TextIOWrapper(
+            io.BufferedWriter(gzip.open(data_lower, "w+")), encoding="utf-8"
+        ) as file_out:
 
-        for line in progressbar.progressbar(file_in):
-            line_lower = line.lower()
-            counter.update(line_lower.split())
-            file_out.write(line_lower)
-
-        file_in.close()
-
-    # Save top-k words
-    print("\nSaving top {} words ...".format(args.top_k))
-    top_counter = counter.most_common(args.top_k)
-    vocab_str = "\n".join(word for word, count in top_counter)
-    vocab_path = "vocab-{}.txt".format(args.top_k)
-    vocab_path = os.path.join(args.output_dir, vocab_path)
-    with open(vocab_path, "w+") as file:
-        file.write(vocab_str)
-
-    print("\nCalculating word statistics ...")
-    total_words = sum(counter.values())
-    print("  Your text file has {} words in total".format(total_words))
-    print("  It has {} unique words".format(len(counter)))
-    top_words_sum = sum(count for word, count in top_counter)
-    word_fraction = (top_words_sum / total_words) * 100
-    print(
-        "  Your top-{} words are {:.4f} percent of all words".format(
-            args.top_k, word_fraction
-        )
-    )
-    print('  Your most common word "{}" occurred {} times'.format(*top_counter[0]))
-    last_word, last_count = top_counter[-1]
-    print(
-        '  The least common word in your top-k is "{}" with {} times'.format(
-            last_word, last_count
-        )
-    )
-    for i, (w, c) in enumerate(reversed(top_counter)):
-        if c > last_count:
-            print(
-                '  The first word with {} occurrences is "{}" at place {}'.format(
-                    c, w, len(top_counter) - 1 - i
+            # Open the input file either from input.txt or input.txt.gz
+            _, file_extension = os.path.splitext(input_txt_item)
+            if file_extension == ".gz":
+                file_in = io.TextIOWrapper(
+                    io.BufferedReader(gzip.open(input_txt_item)), encoding="utf-8"
                 )
-            )
-            break
+            else:
+                file_in = open(input_txt_item, encoding="utf-8")
 
-    return data_lower, vocab_str
+            for line in progressbar.progressbar(file_in):
+                line_lower = line.lower()
+                counter.update(line_lower.split())
+                file_out.write(line_lower)
+
+            file_in.close()
+
+        # Save top-k words
+        print(f"\nSaving top {top_k_item} words ...")
+        top_counter = counter.most_common(top_k_item)
+        vocab_str = "\n".join(word for word, count in top_counter)
+        vocab_str_combined = vocab_str_combined + '\n' + vocab_str
+        vocab_path = f"vocab_{input_txt_num}-{top_k_item}.txt"
+        vocab_path = os.path.join(args.output_dir, vocab_path)
+        vocabs.append(vocab_path)
+        with open(vocab_path, "w+") as file:
+            file.write(vocab_str)
+
+        print(f"\nCalculating word statistics for input_txt {input_txt_num}...")
+        total_words = sum(counter.values())
+        print(f"  Your text file has {total_words} words in total")
+        print(f"  It has {len(counter)} unique words")
+        top_words_sum = sum(count for word, count in top_counter)
+        word_fraction = (top_words_sum / total_words) * 100
+        print(f"  Your top-{top_k_item} words are {word_fraction:.4f}"
+              f" percent of all words")
+        first_word, first_count = top_counter[0]
+        last_word, last_count = top_counter[-1]
+        print(f'  Your most common word "{first_word}" occurred {first_count} times')
+        print(f'  The least common word in your top-k is "{last_word}" with {last_count} times')
+        for i, (w, c) in enumerate(reversed(top_counter)):
+            if c > last_count:
+                print(f'  The first word with {c} occurrences is "{w}"'
+                      f' at place {len(top_counter) - 1 - i}')
+                break
+
+    data_lower = os.path.join(args.output_dir, "lower.txt.gz")
+    # Combine the multiple input_txt iterations
+    with open(data_lower,"wb") as dl:
+        for f in data_lowers:
+            with open(f,"rb") as fd:
+                shutil.copyfileobj(fd, dl)
+            os.remove(f)
+
+    # Combine the multiple vocab iterations
+    vocab_path = os.path.join(args.output_dir, "vocab_combined.txt")
+    with open(vocab_path,"wb") as dl:
+        for f in vocabs:
+            with open(f,"rb") as fd:
+                shutil.copyfileobj(fd, dl)
+            os.remove(f)
+
+    return data_lower, vocab_str_combined
 
 
 def build_lm(args, data_lower, vocab_str):
@@ -103,7 +126,7 @@ def build_lm(args, data_lower, vocab_str):
         [
             os.path.join(args.kenlm_bins, "filter"),
             "single",
-            "model:{}".format(lm_path),
+            f"model:{lm_path}",
             filtered_path,
         ],
         input=vocab_str.encode("utf-8"),
@@ -133,23 +156,31 @@ def main():
         description="Generate lm.binary and top-k vocab for DeepSpeech."
     )
     parser.add_argument(
-        "--input_txt",
-        help="Path to a file.txt or file.txt.gz with sample sentences",
+        "--input_txt", "-i",
+        help="Path to a file.txt or file.txt.gz with sample sentences. "
+             "Pass argument multiple times for multiple files.",
         type=str,
+        action='append',
         required=True,
     )
     parser.add_argument(
-        "--output_dir", help="Directory path for the output", type=str, required=True
+        "--output_dir", "-o",
+        help="Directory path for the output",
+        type=str,
+        required=True
     )
     parser.add_argument(
-        "--top_k",
-        help="Use top_k most frequent words for the vocab.txt file. These will be used to filter the ARPA file.",
+        "--top_k", "-k",
+        help="Use top_k most frequent words for the vocab.txt file. "
+             "These will be used to filter the ARPA file. "
+             "Optionally pass argument multiple times for multiple input_txt files.",
         type=int,
+        action='append',
         required=True,
     )
     parser.add_argument(
         "--kenlm_bins",
-        help="File path to the KENLM binaries lmplz, filter and build_binary",
+        help="File path to the KenLM binaries lmplz, filter and build_binary",
         type=str,
         required=True,
     )
@@ -191,17 +222,37 @@ def main():
     )
     parser.add_argument(
         "--discount_fallback",
-        help="To try when such message is returned by kenlm: 'Could not calculate Kneser-Ney discounts [...] rerun with --discount_fallback'",
+        help="To try when such message is returned by kenlm: 'Could not calculate Kneser-Ney "
+             "discounts [...] rerun with --discount_fallback'",
         action="store_true",
     )
 
     args = parser.parse_args()
 
+    # Basic checks on user supplied arguments
+    if args.kenlm_bins == "path/to/kenlm/build/bin/":
+        parser.error("Update kenlm_bins from documentation value to actual path for kenlm")
+
+    if not os.path.isdir(args.kenlm_bins):
+        parser.error("kenlm_bins must be a valid directory")
+
+    kenlm_files = ["lmplz","filter","build_binary"]
+    for f in kenlm_files:
+        if not os.path.isfile(os.path.join(args.kenlm_bins, f)):
+            parser.error(f"Required kenlm file {f} not found in kenlm_bins directory")
+
+    if len(args.top_k) > len(args.input_txt):
+        parser.error("Number of top_k arguments passed should not exceed number of input_txt"
+                     " arguments passed")
+
+    if not os.path.isdir(args.output_dir):
+        parser.error("output_dir must be a valid directory")
+
     data_lower, vocab_str = convert_and_filter_topk(args)
     build_lm(args, data_lower, vocab_str)
 
     # Delete intermediate files
-    os.remove(os.path.join(args.output_dir, "lower.txt.gz"))
+    os.remove(data_lower)
     os.remove(os.path.join(args.output_dir, "lm.arpa"))
     os.remove(os.path.join(args.output_dir, "lm_filtered.arpa"))
 


### PR DESCRIPTION
Further to discussion [here](https://discourse.mozilla.org/t/discuss-potential-pr-related-to-generate-lm-py/75883?u=nmstoker), this is my PR for enabling **generate_lm.py** to accept multiple input texts which are combined into a single lm.binary output for onward creation of a scorer.

Parameters remain unchanged so shouldn't impact current code, but if you wish to use multiple input texts, you simply pass in multiple --input_txt parameters, like so:

`python generate_lm.py --input_txt input_text_src1.txt.gz --input_txt input_text_src2.txt.gz --output_dir . --top_k 10000 --top_k 20000 --kenlm_bins path/to/kenlm/build/bin/   --arpa_order 5 --max_arpa_memory "85%" --arpa_prune "0|0|1"   --binary_a_bits 255 --binary_q_bits 8 --binary_type trie --discount_fallback`

As per the above example, you can also have corresponding top_k parameters for each input_txt. If you provider fewer top_k parameters (eg just one) then the last one will be re-used for each subsequent input_txt.

BTW: because of using repeating parameters, I didn't need the delimited for inputs I'd mentioned in the Discourse post, and this keeps it pretty simple overall.

As well as the above, I also added a simple parameter check step that runs initially (_simply to avoid situation where you have a trivial error in parameters and have to wait for the first processing step on a large text file to complete before you realise your mistake and have to run it all again!_)

And I switched it to use f-strings over .format (hope that's okay?)

**Documentation:** If this is accepted, provided people agree I plan to put a few extra basic details relating to this in the docs (eg [here](https://github.com/mozilla/DeepSpeech/blob/master/doc/Scorer.rst)) so I'd get a corresponding PR ready for that shortly too. And more generally, I had some ideas I was going to share w/ @KathyReid for the Playbook relating to this.