### PR TITLE
Fix #3511: split-sets on sample size

### DIFF
--- a/bin/import_swb.py
+++ b/bin/import_swb.py
@@ -5,6 +5,7 @@
 import codecs
 import fnmatch
 import os
+import random
 import subprocess
 import sys
 import tarfile
@@ -290,14 +291,18 @@ def _split_wav(origAudio, start_time, stop_time, new_wav_file):
 
 
 def _split_sets(filelist):
-    # We initially split the entire set into 80% train and 20% test, then
-    # split the train set into 80% train and 20% validation.
-    train_beg = 0
-    train_end = int(0.8 * len(filelist))
+    """
+    randomply split the datasets into train, validation, and test sets where the size of the
+    validation and test sets are determined by the `get_sample_size` function. 
+    """
+    random.shuffle(filelist)
+    sample_size = get_sample_size(len(filelist))
 
-    dev_beg = int(0.8 * train_end)
-    dev_end = train_end
-    train_end = dev_beg
+    train_beg = 0
+    train_end = len(filelist) - 2 * sample_size
+
+    dev_beg = train_end
+    dev_end = train_end + sample_size
 
     test_beg = dev_end
     test_end = len(filelist)
@@ -307,6 +312,26 @@ def _split_sets(filelist):
         filelist[dev_beg:dev_end],
         filelist[test_beg:test_end],
     )
+
+
+def get_sample_size(population_size):
+    """calculates the sample size for a 99% confidence and 1% margin of error
+    """
+    margin_of_error = 0.01
+    fraction_picking = 0.50
+    z_score = 2.58  # Corresponds to confidence level 99%
+    numerator = (z_score ** 2 * fraction_picking * (1 - fraction_picking)) / (
+        margin_of_error ** 2
+    )
+    sample_size = 0
+    for train_size in range(population_size, 0, -1):
+        denominator = 1 + (z_score ** 2 * fraction_picking * (1 - fraction_picking)) / (
+            margin_of_error ** 2 * train_size
+        )
+        sample_size = int(numerator / denominator)
+        if 2 * sample_size + train_size <= population_size:
+            break
+    return sample_size
 
 
 def _read_data_set(


### PR DESCRIPTION
Fixes #3511: https://github.com/mozilla/DeepSpeech/issues/3511

Changes the `_split_sets` helper function in `bin/import_swb.py` and `bin/import_fisher.py` to split the training, validation, and test sets based on a sample size using a 99% confidence and 1% margin of error. The `get_sample_size` function was copied from `bin/import_swc.py`. 