### PR TITLE
Support for .net core and .net 5

### DIFF
--- a/native_client/dotnet/DeepSpeech.sln
+++ b/native_client/dotnet/DeepSpeech.sln
@@ -6,6 +6,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeepSpeechClient", "DeepSpe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeepSpeechConsole", "DeepSpeechConsole\DeepSpeechConsole.csproj", "{312965E5-C4F6-4D95-BA64-79906B8BC7AC}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DeepSpeechConsoleNetCore", "DeepSpeechConsoleNetCore\DeepSpeechConsoleNetCore.csproj", "{913D0781-3DCD-43F1-988D-F26622FA0D2B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -20,6 +22,10 @@ Global
 		{312965E5-C4F6-4D95-BA64-79906B8BC7AC}.Debug|x64.Build.0 = Debug|x64
 		{312965E5-C4F6-4D95-BA64-79906B8BC7AC}.Release|x64.ActiveCfg = Release|x64
 		{312965E5-C4F6-4D95-BA64-79906B8BC7AC}.Release|x64.Build.0 = Release|x64
+		{913D0781-3DCD-43F1-988D-F26622FA0D2B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{913D0781-3DCD-43F1-988D-F26622FA0D2B}.Debug|x64.Build.0 = Debug|Any CPU
+		{913D0781-3DCD-43F1-988D-F26622FA0D2B}.Release|x64.ActiveCfg = Release|Any CPU
+		{913D0781-3DCD-43F1-988D-F26622FA0D2B}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/native_client/dotnet/DeepSpeechClient/DeepSpeechClient.csproj
+++ b/native_client/dotnet/DeepSpeechClient/DeepSpeechClient.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 	  <OutputType>Library</OutputType>
-    <TargetFrameworks>net452;net46;net47;uap10.0</TargetFrameworks>
+    <TargetFrameworks>net452;net46;net47;uap10.0;netstandard1.3</TargetFrameworks>
     <Platforms>x64</Platforms>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'">

--- a/native_client/dotnet/DeepSpeechClient/Extensions/NativeExtensions.cs
+++ b/native_client/dotnet/DeepSpeechClient/Extensions/NativeExtensions.cs
@@ -56,7 +56,7 @@ namespace DeepSpeechClient.Extensions
             managedTranscript.Confidence = transcript.confidence;
 
             //we need to manually read each item from the native ptr using its size
-            var sizeOfTokenMetadata = Marshal.SizeOf(typeof(TokenMetadata));
+            var sizeOfTokenMetadata = Marshal.SizeOf<TokenMetadata>();
             for (int i = 0; i < transcript.num_tokens; i++)
             {
                 managedTranscript.Tokens[i] = transcript.tokens.PtrToTokenMetadata();
@@ -79,7 +79,7 @@ namespace DeepSpeechClient.Extensions
             managedMetadata.Transcripts = new Models.CandidateTranscript[metadata.num_transcripts];
 
             //we need to manually read each item from the native ptr using its size
-            var sizeOfCandidateTranscript = Marshal.SizeOf(typeof(CandidateTranscript));
+            var sizeOfCandidateTranscript = Marshal.SizeOf<CandidateTranscript>();
             for (int i = 0; i < metadata.num_transcripts; i++)
             {
                 managedMetadata.Transcripts[i] = metadata.transcripts.PtrToCandidateTranscript();

--- a/native_client/dotnet/DeepSpeechConsoleNetCore/DeepSpeechConsoleNetCore.csproj
+++ b/native_client/dotnet/DeepSpeechConsoleNetCore/DeepSpeechConsoleNetCore.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NAudio" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DeepSpeechClient\DeepSpeechClient.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\DeepSpeechConsole\Program.cs" />
+    <None Include="..\DeepSpeechConsole\arctic_a0024.wav">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Support for netcore and net5 with adding a build to netstandard1.3 (the lowest compatible with the code base).
Fix a warning : Upgrade obsolete SizeOf call.

Add a test netcore console app (into a seperate folder to workaround nuget/msbuild mixing dependencies).

Should fix #3285

netcore/net5 version works fine with NAudio 2.0.0 as demonstrated by console application (Could be a fix for #3540)