### PR TITLE
Small Training Tweaks

### DIFF
--- a/training/deepspeech_training/evaluate.py
+++ b/training/deepspeech_training/evaluate.py
@@ -73,7 +73,8 @@ def evaluate(test_csvs, create_model):
 
     loss = tfv1.nn.ctc_loss(labels=batch_y,
                             inputs=logits,
-                            sequence_length=batch_x_len)
+                            sequence_length=batch_x_len,
+                            ignore_longer_outputs_than_inputs=True)
 
     tfv1.train.get_or_create_global_step()
 

--- a/training/deepspeech_training/evaluate.py
+++ b/training/deepspeech_training/evaluate.py
@@ -73,8 +73,7 @@ def evaluate(test_csvs, create_model):
 
     loss = tfv1.nn.ctc_loss(labels=batch_y,
                             inputs=logits,
-                            sequence_length=batch_x_len,
-                            ignore_longer_outputs_than_inputs=True)
+                            sequence_length=batch_x_len)
 
     tfv1.train.get_or_create_global_step()
 

--- a/training/deepspeech_training/train.py
+++ b/training/deepspeech_training/train.py
@@ -244,7 +244,7 @@ def calculate_mean_edit_distance_and_loss(iterator, dropout, reuse):
     logits, _ = create_model(batch_x, batch_seq_len, dropout, reuse=reuse, rnn_impl=rnn_impl)
 
     # Compute the CTC loss using TensorFlow's `ctc_loss`
-    total_loss = tfv1.nn.ctc_loss(labels=batch_y, inputs=logits, sequence_length=batch_seq_len)
+    total_loss = tfv1.nn.ctc_loss(labels=batch_y, inputs=logits, sequence_length=batch_seq_len, ignore_longer_outputs_than_inputs=True)
 
     # Check if any files lead to non finite loss
     non_finite_files = tf.gather(batch_filenames, tfv1.where(~tf.math.is_finite(total_loss)))

--- a/training/deepspeech_training/train.py
+++ b/training/deepspeech_training/train.py
@@ -814,6 +814,10 @@ def create_inference_graph(batch_size=1, n_steps=16, tflite=False):
         'new_state_c': new_state_c,
         'new_state_h': new_state_h,
         'mfccs': mfccs,
+
+        # Expose internal layers for downstream applications
+        'layer_3': layers['layer_3'],
+        'layer_5': layers['layer_5']
     }
 
     return inputs, outputs, layers

--- a/training/deepspeech_training/train.py
+++ b/training/deepspeech_training/train.py
@@ -244,7 +244,7 @@ def calculate_mean_edit_distance_and_loss(iterator, dropout, reuse):
     logits, _ = create_model(batch_x, batch_seq_len, dropout, reuse=reuse, rnn_impl=rnn_impl)
 
     # Compute the CTC loss using TensorFlow's `ctc_loss`
-    total_loss = tfv1.nn.ctc_loss(labels=batch_y, inputs=logits, sequence_length=batch_seq_len, ignore_longer_outputs_than_inputs=True)
+    total_loss = tfv1.nn.ctc_loss(labels=batch_y, inputs=logits, sequence_length=batch_seq_len)
 
     # Check if any files lead to non finite loss
     non_finite_files = tf.gather(batch_filenames, tfv1.where(~tf.math.is_finite(total_loss)))

--- a/training/deepspeech_training/util/audio.py
+++ b/training/deepspeech_training/util/audio.py
@@ -579,15 +579,23 @@ def get_dtype(audio_format):
 
 
 def pcm_to_np(pcm_data, audio_format=DEFAULT_FORMAT):
+    """
+    Converts PCM data (e.g. read from a wavfile) into a mono numpy column vector
+    with values in the range [0.0, 1.0].
+    """
     # Handles both mono and stero audio
     dtype = get_dtype(audio_format)
     samples = np.frombuffer(pcm_data, dtype=dtype)
+
+    # Read interleaved channels
+    nchannels = audio_format.channels
+    samples = samples.reshape((int(len(samples)/nchannels), nchannels))
+    
+    # Convert to 0.0-1.0 range
     samples = samples.astype(np.float32) / np.iinfo(dtype).max
 
-    if audio_format.channels == 1:
-        return np.expand_dims(samples, axis=1)
-    else:
-        return samples
+    # Average multi-channel clips into mono and turn into column vector
+    return np.expand_dims(np.mean(samples, axis=1), axis=1)
 
 
 def np_to_pcm(np_data, audio_format=DEFAULT_FORMAT):

--- a/training/deepspeech_training/util/audio.py
+++ b/training/deepspeech_training/util/audio.py
@@ -579,17 +579,18 @@ def get_dtype(audio_format):
 
 
 def pcm_to_np(pcm_data, audio_format=DEFAULT_FORMAT):
-    if audio_format.channels != 1:
-        raise ValueError('Mono-channel audio required')
+    # Handles both mono and stero audio
     dtype = get_dtype(audio_format)
     samples = np.frombuffer(pcm_data, dtype=dtype)
     samples = samples.astype(np.float32) / np.iinfo(dtype).max
-    return np.expand_dims(samples, axis=1)
+
+    if audio_format.channels == 1:
+        return np.expand_dims(samples, axis=1)
+    else:
+        return samples
 
 
 def np_to_pcm(np_data, audio_format=DEFAULT_FORMAT):
-    if audio_format.channels != 1:
-        raise ValueError('Mono-channel audio required')
     dtype = get_dtype(audio_format)
     np_data = np_data.squeeze()
     np_data = np_data * np.iinfo(dtype).max


### PR DESCRIPTION
This PR proposes three small training tweaks. Pick and choose as you please, of course.

1. https://github.com/mozilla/DeepSpeech/commit/66f4ed4c65a54ed2e84b263abbfb78ae696b5d40 exposes a couple of the hidden per-CTC-output layers for downstream applications that wish to use deepspeech internal representations
2. ~https://github.com/mozilla/DeepSpeech/commit/2c1b893004e523874465fd18770234692265d51a adds the `ignore_longer_outputs_than_inputs` flag to the tensorflow `ctc_loss` signal. We've found this necessary when training with some slightly messier data. Yes, this should never happen if your data is clean enough, but that's not a guarantee and calculating this as a sanity check upfront can sometimes be difficult. This shouldn't affect DeepSpeech training as it stands, but if you're concerned about it from a "warning" standpoint, I suppose one could add a print op here when it does happen.~
3. https://github.com/mozilla/DeepSpeech/commit/877fef9f2eb49f51a7fa02cd22af312f11c1e957 and https://github.com/mozilla/DeepSpeech/commit/444654036763bdf2bb50826a38426a6f62352963 add multi-channel-to-mono conversion along the way to the `pcm_to_np()` function. In a previous PR (#3512), I had proposed using `AudioFile` as a wrapper for all samples to handle sample rate and channel conversion. @reuben pointed out that sample rate was already handled elsewhere and that TensorFlow's functions can actually handle multi-channel audio just fine. Both are correct, of course, but the training code currently still threw an error when handed multi-channel files. To get past that, I tried briefly to see if I could just eliminate the warning and pass multi-channel audio, either interleaved or as a 2-column matrix for stereo, but this breaks downstream (for interleaved, the CTCs become garbage, if I return two column vectors here, I get 2x the CTCs and the decoder produces the same output twice). So I did the channel conversion right here along the way. I think this has some benefits as well as we really only care about performing the downstream augmentations and training on mono audio ever, so it seems prudent performance-wise to always read it in as mono…