### PR TITLE
BUG-FIX: revert breaking change for building nodeJS bindings from commit 5e4d7dae

### DIFF
--- a/native_client/javascript/deepspeech.i
+++ b/native_client/javascript/deepspeech.i
@@ -46,7 +46,7 @@ using namespace node;
 }
 
 %typemap(argout) ModelState **retval {
-  $result = SWIGV8_ARRAY_NEW(0);
+  $result = SWIGV8_ARRAY_NEW();
   SWIGV8_AppendOutput($result, SWIG_From_int(result));
   // owned by the application. NodeJS does not guarantee the finalizer will be called so applications must call FreeMetadata themselves.
   %append_output(SWIG_NewPointerObj(%as_voidptr(*$1), $*1_descriptor, 0));
@@ -60,7 +60,7 @@ using namespace node;
 }
 
 %typemap(argout) StreamingState **retval {
-  $result = SWIGV8_ARRAY_NEW(0);
+  $result = SWIGV8_ARRAY_NEW();
   SWIGV8_AppendOutput($result, SWIG_From_int(result));
   // not owned, DS_FinishStream deallocates StreamingState
   %append_output(SWIG_NewPointerObj(%as_voidptr(*$1), $*1_descriptor, 0));
@@ -70,14 +70,14 @@ using namespace node;
 %nodefaultdtor ModelState;
 
 %typemap(out) TokenMetadata* %{
-  $result = SWIGV8_ARRAY_NEW(0);
+  $result = SWIGV8_ARRAY_NEW();
   for (int i = 0; i < arg1->num_tokens; ++i) {
     SWIGV8_AppendOutput($result, SWIG_NewPointerObj(SWIG_as_voidptr(&result[i]), SWIGTYPE_p_TokenMetadata, 0));
   }
 %}
 
 %typemap(out) CandidateTranscript* %{
-  $result = SWIGV8_ARRAY_NEW(0);
+  $result = SWIGV8_ARRAY_NEW();
   for (int i = 0; i < arg1->num_transcripts; ++i) {
     SWIGV8_AppendOutput($result, SWIG_NewPointerObj(SWIG_as_voidptr(&result[i]), SWIGTYPE_p_CandidateTranscript, 0));
   }


### PR DESCRIPTION
Without this change reverted, attempting to build nodeJS bindings by running `make build` as described [here](https://deepspeech.readthedocs.io/en/latest/BUILDING.html#install-nodejs-electronjs-bindings) on ubuntu 20.04 resulted the following error: `error: macro "SWIGV8_ARRAY_NEW" passed 1 arguments, but takes just 0
 2067 |     jsresult = SWIGV8_ARRAY_NEW(0);`.

Here is more of the surrounding output
```
make[1]: Entering directory '/home/patrick/DeepSpeech/native_client/javascript/build'
  c++ '-DNODE_GYP_MODULE_NAME=deepspeech' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-DV8_DEPRECATION_WARNINGS' '-DV8_IMMINENT_DEPRECATION_WARNINGS' '-D_LARGEFILE_SOURCE' '-D_FILE_OFFSET_BITS=64' '-D__STDC_FORMAT_MACROS' '-DOPENSSL_NO_PINSHARED' '-DOPENSSL_THREADS' '-DBUILDING_NODE_EXTENSION' -I/home/patrick/.cache/node-gyp/14.16.1/include/node -I/home/patrick/.cache/node-gyp/14.16.1/src -I/home/patrick/.cache/node-gyp/14.16.1/deps/openssl/config -I/home/patrick/.cache/node-gyp/14.16.1/deps/openssl/openssl/include -I/home/patrick/.cache/node-gyp/14.16.1/deps/uv/include -I/home/patrick/.cache/node-gyp/14.16.1/deps/zlib -I/home/patrick/.cache/node-gyp/14.16.1/deps/v8/include -I../..  -fPIC -pthread -Wall -Wextra -Wno-unused-parameter -m64 -O3 -fno-omit-frame-pointer -fno-rtti -fno-exceptions -std=gnu++1y -MMD -MF ./Release/.deps/Release/obj.target/deepspeech/deepspeech_wrap.o.d.raw    -c -o Release/obj.target/deepspeech/deepspeech_wrap.o ../deepspeech_wrap.cxx
../deepspeech_wrap.cxx:2067:34: error: macro "SWIGV8_ARRAY_NEW" passed 1 arguments, but takes just 0
 2067 |     jsresult = SWIGV8_ARRAY_NEW(0);
      |                                  ^
../deepspeech_wrap.cxx:862: note: macro "SWIGV8_ARRAY_NEW" defined here
  862 | #define SWIGV8_ARRAY_NEW() v8::Array::New(v8::Isolate::GetCurrent())
      | 
../deepspeech_wrap.cxx:2141:34: error: macro "SWIGV8_ARRAY_NEW" passed 1 arguments, but takes just 0
 2141 |     jsresult = SWIGV8_ARRAY_NEW(0);
      |                                  ^
../deepspeech_wrap.cxx:862: note: macro "SWIGV8_ARRAY_NEW" defined here
  862 | #define SWIGV8_ARRAY_NEW() v8::Array::New(v8::Isolate::GetCurrent())
      | 
../deepspeech_wrap.cxx:2628:34: error: macro "SWIGV8_ARRAY_NEW" passed 1 arguments, but takes just 0
 2628 |     jsresult = SWIGV8_ARRAY_NEW(0);
      |                                  ^
../deepspeech_wrap.cxx:862: note: macro "SWIGV8_ARRAY_NEW" defined here
  862 | #define SWIGV8_ARRAY_NEW() v8::Array::New(v8::Isolate::GetCurrent())
      | 
../deepspeech_wrap.cxx:3108:34: error: macro "SWIGV8_ARRAY_NEW" passed 1 arguments, but takes just 0
 3108 |     jsresult = SWIGV8_ARRAY_NEW(0);
      |                                  ^
../deepspeech_wrap.cxx:862: note: macro "SWIGV8_ARRAY_NEW" defined here
  862 | #define SWIGV8_ARRAY_NEW() v8::Array::New(v8::Isolate::GetCurrent())
      | 
../deepspeech_wrap.cxx: In function ‘v8::Local<v8::Value> SWIGV8_AppendOutput(v8::Local<v8::Value>, v8::Local<v8::Value>)’:
../deepspeech_wrap.cxx:1479:56: warning: ignoring return value of ‘v8::Maybe<bool> v8::Object::Set(v8::Local<v8::Context>, uint32_t, v8::Local<v8::Value>)’, declared with attribute warn_unused_result [-Wunused-result]
 1479 |   arr->Set(SWIGV8_CURRENT_CONTEXT(), arr->Length(), obj);
      |                                                        ^
In file included from /home/patrick/.cache/node-gyp/14.16.1/include/node/node.h:67,
                 from ../deepspeech_wrap.cxx:171:
/home/patrick/.cache/node-gyp/14.16.1/include/node/v8.h:3673:37: note: declared here
 3673 |   V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context, uint32_t index,
      |                                     ^~~
../deepspeech_wrap.cxx: In function ‘void SWIGV8_AddStaticFunction(v8::Local<v8::Object>, const char*, void (* const&)(const v8::FunctionCallbackInfo<v8::Value>&))’:
../deepspeech_wrap.cxx:1554:151: warning: ignoring return value of ‘v8::Maybe<bool> v8::Object::Set(v8::Local<v8::Context>, v8::Local<v8::Value>, v8::Local<v8::Value>)’, declared with attribute warn_unused_result [-Wunused-result]
 1554 | func)->GetFunction(SWIGV8_CURRENT_CONTEXT()).ToLocalChecked());
      |                                                              ^

In file included from /home/patrick/.cache/node-gyp/14.16.1/include/node/node.h:67,
                 from ../deepspeech_wrap.cxx:171:
/home/patrick/.cache/node-gyp/14.16.1/include/node/v8.h:3670:37: note: declared here
 3670 |   V8_WARN_UNUSED_RESULT Maybe<bool> Set(Local<Context> context,
      |                                     ^~~
../deepspeech_wrap.cxx: In function ‘void SWIGV8_AddStaticVariable(v8::Local<v8::Object>, const char*, SwigV8AccessorGetterCallback, SwigV8AccessorSetterCallback)’:
../deepspeech_wrap.cxx:1566:87: warning: ignoring return value of ‘v8::Maybe<bool> v8::Object::SetAccessor(v8::Local<v8::Context>, v8::Local<v8::Name>, v8::AccessorNameGetterCallback, v8::AccessorNameSetterCallback, v8::MaybeLocal<v8::Value>, v8::AccessControl, v8::PropertyAttribute, v8::SideEffectType, v8::SideEffectType)’, declared with attribute warn_unused_result [-Wunused-result]
 1566 | _CURRENT_CONTEXT(), SWIGV8_SYMBOL_NEW(symbol), getter, setter);
      |                                                              ^

In file included from /home/patrick/.cache/node-gyp/14.16.1/include/node/node.h:67,
                 from ../deepspeech_wrap.cxx:171:
/home/patrick/.cache/node-gyp/14.16.1/include/node/v8.h:3766:37: note: declared here
 3766 |   V8_WARN_UNUSED_RESULT Maybe<bool> SetAccessor(
      |                                     ^~~~~~~~~~~
../deepspeech_wrap.cxx: In function ‘SwigV8ReturnValue _wrap_CandidateTranscript_tokens_get(v8::Local<v8::Name>, const SwigV8PropertyCallbackInfo&)’:
../deepspeech_wrap.cxx:2067:16: error: ‘SWIGV8_ARRAY_NEW’ was not declared in this scope
 2067 |     jsresult = SWIGV8_ARRAY_NEW(0);
      |                ^~~~~~~~~~~~~~~~
../deepspeech_wrap.cxx:2068:23: warning: comparison of integer expressions of different signedness: ‘int’ and ‘const unsigned int’ [-Wsign-compare]
 2068 |     for (int i = 0; i < arg1->num_tokens; ++i) {
      |                     ~~^~~~~~~~~~~~~~~~~~
../deepspeech_wrap.cxx: In function ‘SwigV8ReturnValue _wrap_Metadata_transcripts_get(v8::Local<v8::Name>, const SwigV8PropertyCallbackInfo&)’:
../deepspeech_wrap.cxx:2141:16: error: ‘SWIGV8_ARRAY_NEW’ was not declared in this scope
 2141 |     jsresult = SWIGV8_ARRAY_NEW(0);
      |                ^~~~~~~~~~~~~~~~
../deepspeech_wrap.cxx:2142:23: warning: comparison of integer expressions of different signedness: ‘int’ and ‘const unsigned int’ [-Wsign-compare]
 2142 |     for (int i = 0; i < arg1->num_transcripts; ++i) {
      |                     ~~^~~~~~~~~~~~~~~~~~~~~~~
../deepspeech_wrap.cxx: In function ‘SwigV8ReturnValue _wrap_CreateModel(const SwigV8Arguments&)’:
../deepspeech_wrap.cxx:2628:16: error: ‘SWIGV8_ARRAY_NEW’ was not declared in this scope
 2628 |     jsresult = SWIGV8_ARRAY_NEW(0);
      |                ^~~~~~~~~~~~~~~~
../deepspeech_wrap.cxx: In function ‘SwigV8ReturnValue _wrap_CreateStream(const SwigV8Arguments&)’:
../deepspeech_wrap.cxx:3108:16: error: ‘SWIGV8_ARRAY_NEW’ was not declared in this scope
 3108 |     jsresult = SWIGV8_ARRAY_NEW(0);
      |                ^~~~~~~~~~~~~~~~

```