### PR TITLE
Swift Client: Fix double deallocation

### DIFF
--- a/native_client/swift/deepspeech_ios/DeepSpeech.swift
+++ b/native_client/swift/deepspeech_ios/DeepSpeech.swift
@@ -283,7 +283,10 @@ public class DeepSpeechStream {
         precondition(streamCtx != nil, "calling method on invalidated Stream")
 
         let result = DS_FinishStreamWithMetadata(streamCtx, UInt32(numResults))!
-        defer { DS_FreeMetadata(result) }
+        defer {
+            DS_FreeMetadata(result)
+            streamCtx = nil
+        }
         return DeepSpeechMetadata(fromInternal: result)
     }
 }


### PR DESCRIPTION
Hello,

This PR is an attempt to fix a double deallocation issue in the Swift client.

## How to produce

1. In the Swift demo project deepspeech_ios_test, locate the file SpeechRecognitionImpl.swift, and replace `let result = stream.finishStream()` with `let result = stream.finishStreamWithMetadata(numResults: 1)`
1. Run the app and click the button "Recognize files".
1. The app will crash as soon as the associated `DeepSpeechStream` is deallocated. In my case, Xcode prompted something like "Thread XXX: Deallocation of freed memory".

## References
* @zaptrem also mentioned a similar issue in https://github.com/mozilla/DeepSpeech/issues/3061#issuecomment-776199055: "I'm using intermediateDecodeWithMetadata as finishStreamWithMetadata also has an unknown crash".

## Fix
Seems the fix can be as simple as adding one line of code. After the patch, the code pattern of `finishStreamWithMetadata(numResults:)` now aligns with `finishStream()`.

## Thank you
Would like to thank @reuben for the Swift wrapper-related work!

