### PR TITLE
Update hyperparameter optimization code for Optuna v3.0.0

### DIFF
--- a/lm_optimizer.py
+++ b/lm_optimizer.py
@@ -24,8 +24,8 @@ def character_based():
     return is_character_based
 
 def objective(trial):
-    FLAGS.lm_alpha = trial.suggest_uniform('lm_alpha', 0, FLAGS.lm_alpha_max)
-    FLAGS.lm_beta = trial.suggest_uniform('lm_beta', 0, FLAGS.lm_beta_max)
+    FLAGS.lm_alpha = trial.suggest_float('lm_alpha', 0, FLAGS.lm_alpha_max)
+    FLAGS.lm_beta = trial.suggest_float('lm_beta', 0, FLAGS.lm_beta_max)
 
     is_character_based = trial.study.user_attrs['is_character_based']
 


### PR DESCRIPTION
## Motivation

Optuna v3.0.0 was released in 29 August 2022, and `Trial.suggest_uniform` was deprecated. Please use `Trial.suggest_float` as described in the [migration guide](https://github.com/optuna/optuna/discussions/3930#discussion-4331830).

## Changes

This PR simply replace `Trial.suggest_uniform` with `Trial.suggest_float`. This does not change the behavior since `Trial.suggest_uniform` is now just an alias of `Trial.suggest_float` as can be seen in this [source code](https://github.com/optuna/optuna/blob/09659ce5b655f0848e9b7982c113b421a419a413/optuna/trial/_trial.py#L158-L178.).