### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/actions/get_cache_key/action.yml
+++ b/.github/actions/get_cache_key/action.yml
@@ -29,5 +29,5 @@ runs:
         SHA=$(git submodule status ${SUBMODULE} | sed -e 's/^-//g' -e 's/^+//g' -e 's/^U//g' | awk '{ print $1 }')
 
         KEY=${SUBMODULE}-${FLAVOR}_${OSARCH}_${SHA}_${{ inputs.extras }}
-        echo "::set-output name=key::${KEY}"
+        echo "key=${KEY}" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/numpy_vers/action.yml
+++ b/.github/actions/numpy_vers/action.yml
@@ -88,6 +88,6 @@ runs:
             ;;
         esac
 
-        echo "::set-output name=build::${NUMPY_BUILD_VERSION}"
-        echo "::set-output name=dep::${NUMPY_DEP_VERSION}"
+        echo "build=${NUMPY_BUILD_VERSION}" >> $GITHUB_OUTPUT
+        echo "dep=${NUMPY_DEP_VERSION}" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1584,7 +1584,7 @@ jobs:
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         id: node-modules-cache
         with:
@@ -1652,7 +1652,7 @@ jobs:
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         id: electron-modules-cache
         with:
@@ -1995,7 +1995,7 @@ jobs:
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         id: node-modules-cache
         with:
@@ -2063,7 +2063,7 @@ jobs:
       - name: Get npm cache directory
         id: npm-cache-dir
         run: |
-          echo "::set-output name=dir::$(npm config get cache)"
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         id: electron-modules-cache
         with:


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


